### PR TITLE
Adding unit test for ScmpAction

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -913,10 +913,46 @@ mod tests {
             ScmpAction::KillProcess.to_native()
         );
         assert_eq!(
+            ScmpAction::from_str("SCMP_ACT_KILL_THREAD", None)
+                .unwrap()
+                .to_native(),
+            ScmpAction::KillThread.to_native()
+        );
+        assert_eq!(
+            ScmpAction::from_str("SCMP_ACT_TRAP", None)
+                .unwrap()
+                .to_native(),
+            ScmpAction::Trap.to_native()
+        );
+        assert_eq!(
+            ScmpAction::from_str("SCMP_ACT_NOTIFY", None)
+                .unwrap()
+                .to_native(),
+            ScmpAction::Notify.to_native()
+        );
+        assert_eq!(
             ScmpAction::from_str("SCMP_ACT_ERRNO", Some(10))
                 .unwrap()
                 .to_native(),
             ScmpAction::Errno(10).to_native()
+        );
+        assert_eq!(
+            ScmpAction::from_str("SCMP_ACT_TRACE", Some(10))
+                .unwrap()
+                .to_native(),
+            ScmpAction::Trace(10).to_native()
+        );
+        assert_eq!(
+            ScmpAction::from_str("SCMP_ACT_LOG", None)
+                .unwrap()
+                .to_native(),
+            ScmpAction::Log.to_native()
+        );
+        assert_eq!(
+            ScmpAction::from_str("SCMP_ACT_ALLOW", None)
+                .unwrap()
+                .to_native(),
+            ScmpAction::Allow.to_native()
         );
         assert_eq!(
             ScmpArch::from_str("SCMP_ARCH_X86_64").unwrap().to_native(),


### PR DESCRIPTION
- Unit tests have been added for ScmpAction - SCMP_ACT_KILL_THREAD, SCMP_ACT_KILL, SCMP_ACT_TRAP, , SCMP_ACT_NOTIFY, SCMP_ACT_ERRNO, SCMP_ACT_TRACE, SCMP_ACT_LOG, SCMP_ACT_ALLOW

Signed-off-by: Savithry <savithry.jayaraman@sony.com>