### PR TITLE
Call sync_all in export_{pfc,bpf}

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -630,6 +630,9 @@ impl ScmpFilterContext {
         if ret < 0 {
             return Err(SeccompError::new(Errno(ret)));
         }
+        // TODO: use implicit From::from
+        fd.sync_all()
+            .map_err(|e| SeccompError::with_source(Common(e.to_string()), e))?;
 
         Ok(())
     }
@@ -644,6 +647,9 @@ impl ScmpFilterContext {
         if ret < 0 {
             return Err(SeccompError::new(Errno(ret)));
         }
+        // TODO: use implicit From::from
+        fd.sync_all()
+            .map_err(|e| SeccompError::with_source(Common(e.to_string()), e))?;
 
         Ok(())
     }


### PR DESCRIPTION
> Files are automatically closed when they go out of scope. Errors detected on
> closing are ignored by the implementation of Drop. Use the method sync_all if
> these errors must be manually handled.

Beause we take ownership of the File, I think it is a good idea to give
callers a chance to handle such errors.

----

This PR should be rebased after #27 is merged and use implicit `from` instead of `map_err`.