### PR TITLE
Rustify get_native_arch

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -382,6 +382,44 @@ impl ScmpArch {
             Self::Riscv64 => SCMP_ARCH_RISCV64,
         }
     }
+
+    fn from_sys(arch: u32) -> Result<Self> {
+        match arch {
+            SCMP_ARCH_NATIVE => Ok(Self::Native),
+            SCMP_ARCH_X86 => Ok(Self::X86),
+            SCMP_ARCH_X86_64 => Ok(Self::X8664),
+            SCMP_ARCH_X32 => Ok(Self::X32),
+            SCMP_ARCH_ARM => Ok(Self::Arm),
+            SCMP_ARCH_AARCH64 => Ok(Self::Aarch64),
+            SCMP_ARCH_MIPS => Ok(Self::Mips),
+            SCMP_ARCH_MIPS64 => Ok(Self::Mips64),
+            SCMP_ARCH_MIPS64N32 => Ok(Self::Mips64N32),
+            SCMP_ARCH_MIPSEL => Ok(Self::Mipsel),
+            SCMP_ARCH_MIPSEL64 => Ok(Self::Mipsel64),
+            SCMP_ARCH_MIPSEL64N32 => Ok(Self::Mipsel64N32),
+            SCMP_ARCH_PPC => Ok(Self::Ppc),
+            SCMP_ARCH_PPC64 => Ok(Self::Ppc64),
+            SCMP_ARCH_PPC64LE => Ok(Self::Ppc64Le),
+            SCMP_ARCH_S390 => Ok(Self::S390),
+            SCMP_ARCH_S390X => Ok(Self::S390X),
+            SCMP_ARCH_PARISC => Ok(Self::Parisc),
+            SCMP_ARCH_PARISC64 => Ok(Self::Parisc64),
+            SCMP_ARCH_RISCV64 => Ok(Self::Riscv64),
+            _ => Err(SeccompError::new(ParseError)),
+        }
+    }
+
+    /// Returns the system's native architecture.
+    pub fn native() -> Result<Self> {
+        let ret = unsafe { seccomp_arch_native() };
+
+        match Self::from_sys(ret) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(SeccompError::new(Common(
+                "Could not get native architecture".to_string(),
+            ))),
+        }
+    }
 }
 
 impl std::str::FromStr for ScmpArch {
@@ -410,32 +448,6 @@ impl std::str::FromStr for ScmpArch {
             "SCMP_ARCH_RISCV64" => Ok(Self::Riscv64),
             _ => Err(SeccompError::new(ParseError)),
         }
-    }
-}
-
-fn arch_from_native(arch: u32) -> Result<ScmpArch> {
-    match arch {
-        SCMP_ARCH_NATIVE => Ok(ScmpArch::Native),
-        SCMP_ARCH_X86 => Ok(ScmpArch::X86),
-        SCMP_ARCH_X86_64 => Ok(ScmpArch::X8664),
-        SCMP_ARCH_X32 => Ok(ScmpArch::X32),
-        SCMP_ARCH_ARM => Ok(ScmpArch::Arm),
-        SCMP_ARCH_AARCH64 => Ok(ScmpArch::Aarch64),
-        SCMP_ARCH_MIPS => Ok(ScmpArch::Mips),
-        SCMP_ARCH_MIPS64 => Ok(ScmpArch::Mips64),
-        SCMP_ARCH_MIPS64N32 => Ok(ScmpArch::Mips64N32),
-        SCMP_ARCH_MIPSEL => Ok(ScmpArch::Mipsel),
-        SCMP_ARCH_MIPSEL64 => Ok(ScmpArch::Mipsel64),
-        SCMP_ARCH_MIPSEL64N32 => Ok(ScmpArch::Mipsel64N32),
-        SCMP_ARCH_PPC => Ok(ScmpArch::Ppc),
-        SCMP_ARCH_PPC64 => Ok(ScmpArch::Ppc64),
-        SCMP_ARCH_PPC64LE => Ok(ScmpArch::Ppc64Le),
-        SCMP_ARCH_S390 => Ok(ScmpArch::S390),
-        SCMP_ARCH_S390X => Ok(ScmpArch::S390X),
-        SCMP_ARCH_PARISC => Ok(ScmpArch::Parisc),
-        SCMP_ARCH_PARISC64 => Ok(ScmpArch::Parisc64),
-        SCMP_ARCH_RISCV64 => Ok(ScmpArch::Riscv64),
-        _ => Err(SeccompError::new(ParseError)),
     }
 }
 
@@ -707,19 +719,10 @@ pub fn get_library_version() -> Result<ScmpVersion> {
     ScmpVersion::current()
 }
 
-/// get_native_arch returns ScmpArch representing the native kernel architecture.
-///
-/// Returns a native architecture, or an error if the function could not get
-/// the native architecture.
+/// Deprecated alias for [`ScmpArch::native()`].
+#[deprecated(since = "0.2.0", note = "Use ScmpArch::native()")]
 pub fn get_native_arch() -> Result<ScmpArch> {
-    let ret = unsafe { seccomp_arch_native() };
-
-    match arch_from_native(ret) {
-        Ok(v) => Ok(v),
-        Err(_) => Err(SeccompError::new(Common(
-            "Could not get native architecture".to_string(),
-        ))),
-    }
+    ScmpArch::native()
 }
 
 /// get_api returns the API level supported by the system.
@@ -952,7 +955,7 @@ mod tests {
 
     #[test]
     fn test_get_native_arch() {
-        let ret = get_native_arch().unwrap();
+        let ret = ScmpArch::native().unwrap();
         println!("test_get_native_arch: native arch is {:?}", ret);
     }
 
@@ -1033,7 +1036,7 @@ mod tests {
     fn test_merge_filters() {
         let mut ctx1 = ScmpFilterContext::new_filter(ScmpAction::Allow).unwrap();
         let mut ctx2 = ScmpFilterContext::new_filter(ScmpAction::Allow).unwrap();
-        let native_arch = get_native_arch().unwrap();
+        let native_arch = ScmpArch::native().unwrap();
         let mut prospective_arch = ScmpArch::Aarch64;
 
         if native_arch == ScmpArch::Aarch64 {

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -113,7 +113,7 @@ pub enum ScmpFilterAttr {
 }
 
 impl ScmpFilterAttr {
-    pub fn to_native(self) -> scmp_filter_attr {
+    fn to_sys(self) -> scmp_filter_attr {
         match self {
             Self::ActDefault => scmp_filter_attr::SCMP_FLTATR_ACT_DEFAULT,
             Self::ActBadArch => scmp_filter_attr::SCMP_FLTATR_ACT_BADARCH,
@@ -168,7 +168,7 @@ pub enum ScmpCompareOp {
 }
 
 impl ScmpCompareOp {
-    pub fn to_native(self) -> scmp_compare {
+    fn to_sys(self) -> scmp_compare {
         match self {
             Self::NotEqual => scmp_compare::SCMP_CMP_NE,
             Self::Less => scmp_compare::SCMP_CMP_LT,
@@ -230,7 +230,7 @@ impl From<ScmpArgCompare> for scmp_arg_cmp {
     fn from(v: ScmpArgCompare) -> scmp_arg_cmp {
         scmp_arg_cmp {
             arg: v.arg,
-            op: v.op.to_native(),
+            op: v.op.to_sys(),
             datum_a: v.datum_a,
             datum_b: v.datum_b,
         }
@@ -241,7 +241,7 @@ impl From<&ScmpArgCompare> for scmp_arg_cmp {
     fn from(v: &ScmpArgCompare) -> scmp_arg_cmp {
         scmp_arg_cmp {
             arg: v.arg,
-            op: v.op.to_native(),
+            op: v.op.to_sys(),
             datum_a: v.datum_a,
             datum_b: v.datum_b,
         }
@@ -272,7 +272,7 @@ pub enum ScmpAction {
 }
 
 impl ScmpAction {
-    pub fn to_native(self) -> u32 {
+    fn to_sys(self) -> u32 {
         match self {
             Self::KillProcess => SCMP_ACT_KILL_PROCESS,
             Self::KillThread => SCMP_ACT_KILL_THREAD,
@@ -358,7 +358,7 @@ pub enum ScmpArch {
 }
 
 impl ScmpArch {
-    pub fn to_native(self) -> u32 {
+    fn to_sys(self) -> u32 {
         match self {
             Self::Native => SCMP_ARCH_NATIVE,
             Self::X86 => SCMP_ARCH_X86,
@@ -452,7 +452,7 @@ impl ScmpFilterContext {
     /// Returns a reference to a valid filter context, or an error if the
     /// filter context could not be created or an invalid default action was given.
     pub fn new_filter(default_action: ScmpAction) -> Result<ScmpFilterContext> {
-        let ctx_ptr = unsafe { seccomp_init(default_action.to_native()) };
+        let ctx_ptr = unsafe { seccomp_init(default_action.to_sys()) };
         let ctx = NonNull::new(ctx_ptr)
             .ok_or_else(|| SeccompError::new(Common("Could not create new filter".to_string())))?;
 
@@ -493,7 +493,7 @@ impl ScmpFilterContext {
     /// and an error on an invalid filter context, architecture constant, or an
     /// issue with the call to libseccomp
     pub fn is_arch_present(&self, arch: ScmpArch) -> Result<bool> {
-        let ret = unsafe { seccomp_arch_exist(self.ctx.as_ptr(), arch.to_native()) };
+        let ret = unsafe { seccomp_arch_exist(self.ctx.as_ptr(), arch.to_sys()) };
 
         if ret != 0 {
             if ret == -(libc::EEXIST as i32) {
@@ -510,7 +510,7 @@ impl ScmpFilterContext {
     /// Accepts an architecture constant.
     /// Returns an architecture token, or an error with the call to libseccomp.
     pub fn add_arch(&mut self, arch: ScmpArch) -> Result<()> {
-        let ret = unsafe { seccomp_arch_add(self.ctx.as_ptr(), arch.to_native()) };
+        let ret = unsafe { seccomp_arch_add(self.ctx.as_ptr(), arch.to_sys()) };
 
         // Libseccomp returns -EEXIST if the specified architecture is already
         // present. Succeed silently in this case, as it's not fatal, and the
@@ -528,7 +528,7 @@ impl ScmpFilterContext {
     /// Returns an error on invalid filter context or architecture token, or an
     /// issue with the call to libseccomp.
     pub fn remove_arch(&mut self, arch: ScmpArch) -> Result<()> {
-        let ret = unsafe { seccomp_arch_remove(self.ctx.as_ptr(), arch.to_native()) };
+        let ret = unsafe { seccomp_arch_remove(self.ctx.as_ptr(), arch.to_sys()) };
 
         // Similar to add_arch, -EEXIST is returned if the arch is not present
         // Succeed silently in that case, this is not fatal and the architecture
@@ -567,7 +567,7 @@ impl ScmpFilterContext {
                 ret = unsafe {
                     seccomp_rule_add_array(
                         self.ctx.as_ptr(),
-                        action.to_native(),
+                        action.to_sys(),
                         syscall,
                         arg_cmp_len,
                         arg_cmp.as_ptr(),
@@ -575,8 +575,7 @@ impl ScmpFilterContext {
                 };
             }
             None => {
-                ret =
-                    unsafe { seccomp_rule_add(self.ctx.as_ptr(), action.to_native(), syscall, 0) };
+                ret = unsafe { seccomp_rule_add(self.ctx.as_ptr(), action.to_sys(), syscall, 0) };
             }
         };
 
@@ -602,7 +601,7 @@ impl ScmpFilterContext {
     pub fn get_filter_attr(&self, attr: ScmpFilterAttr) -> Result<u32> {
         let mut attribute: u32 = 0;
 
-        let ret = unsafe { seccomp_attr_get(self.ctx.as_ptr(), attr.to_native(), &mut attribute) };
+        let ret = unsafe { seccomp_attr_get(self.ctx.as_ptr(), attr.to_sys(), &mut attribute) };
         if ret < 0 {
             return Err(SeccompError::new(Errno(ret)));
         }
@@ -621,7 +620,7 @@ impl ScmpFilterContext {
 
     /// set_filter_attr sets a raw filter attribute
     pub fn set_filter_attr(&mut self, attr: ScmpFilterAttr, value: u32) -> Result<()> {
-        let ret = unsafe { seccomp_attr_set(self.ctx.as_ptr(), attr.to_native(), value) };
+        let ret = unsafe { seccomp_attr_set(self.ctx.as_ptr(), attr.to_sys(), value) };
         if ret < 0 {
             return Err(SeccompError::new(Errno(ret)));
         }
@@ -684,7 +683,7 @@ impl ScmpFilterContext {
     /// Accepts a new default action to be taken for syscalls which do not match.
     /// Returns an error if the filter or action provided are invalid.
     pub fn reset(&mut self, action: ScmpAction) -> Result<()> {
-        let ret = unsafe { seccomp_reset(self.ctx.as_ptr(), action.to_native()) };
+        let ret = unsafe { seccomp_reset(self.ctx.as_ptr(), action.to_sys()) };
         if ret < 0 {
             return Err(SeccompError::new(Errno(ret)));
         }
@@ -766,7 +765,7 @@ pub fn set_api(level: u32) -> Result<()> {
 /// Returns either a string containing the name of the syscall, or an error.
 /// if the syscall is unrecognized or an issue occurred.
 pub fn get_syscall_name_from_arch(arch: ScmpArch, syscall_num: i32) -> Result<String> {
-    let ret = unsafe { seccomp_syscall_resolve_num_arch(arch.to_native(), syscall_num) };
+    let ret = unsafe { seccomp_syscall_resolve_num_arch(arch.to_sys(), syscall_num) };
     if ret.is_null() {
         return Err(SeccompError::new(Common(format!(
             "Could not resolve syscall number {}",
@@ -797,8 +796,7 @@ pub fn get_syscall_from_name(name: &str, arch: Option<ScmpArch>) -> Result<i32> 
 
     match arch {
         Some(arch) => {
-            syscall =
-                unsafe { seccomp_syscall_resolve_name_arch(arch.to_native(), name_c.as_ptr()) };
+            syscall = unsafe { seccomp_syscall_resolve_name_arch(arch.to_sys(), name_c.as_ptr()) };
         }
         None => {
             syscall = unsafe { seccomp_syscall_resolve_name(name_c.as_ptr()) };
@@ -836,110 +834,110 @@ mod tests {
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_ACT_DEFAULT")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::ActDefault.to_native()
+                .to_sys(),
+            ScmpFilterAttr::ActDefault.to_sys()
         );
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_ACT_BADARCH")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::ActBadArch.to_native()
+                .to_sys(),
+            ScmpFilterAttr::ActBadArch.to_sys()
         );
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_CTL_NNP")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::CtlNnp.to_native()
+                .to_sys(),
+            ScmpFilterAttr::CtlNnp.to_sys()
         );
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_CTL_TSYNC")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::CtlTsync.to_native()
+                .to_sys(),
+            ScmpFilterAttr::CtlTsync.to_sys()
         );
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_API_TSKIP")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::ApiTskip.to_native()
+                .to_sys(),
+            ScmpFilterAttr::ApiTskip.to_sys()
         );
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_CTL_LOG")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::CtlLog.to_native()
+                .to_sys(),
+            ScmpFilterAttr::CtlLog.to_sys()
         );
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_CTL_SSB")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::CtlSsb.to_native()
+                .to_sys(),
+            ScmpFilterAttr::CtlSsb.to_sys()
         );
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_CTL_OPTIMIZE")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::CtlOptimize.to_native()
+                .to_sys(),
+            ScmpFilterAttr::CtlOptimize.to_sys()
         );
         assert_eq!(
             ScmpFilterAttr::from_str("SCMP_FLTATR_API_SYSRAWRC")
                 .unwrap()
-                .to_native(),
-            ScmpFilterAttr::ApiSysRawRc.to_native()
+                .to_sys(),
+            ScmpFilterAttr::ApiSysRawRc.to_sys()
         );
         assert!(ScmpFilterAttr::from_str("SCMP_INVALID_FLAG").is_err());
         assert_eq!(
-            ScmpCompareOp::from_str("SCMP_CMP_NE").unwrap().to_native(),
-            ScmpCompareOp::NotEqual.to_native()
+            ScmpCompareOp::from_str("SCMP_CMP_NE").unwrap().to_sys(),
+            ScmpCompareOp::NotEqual.to_sys()
         );
         assert_eq!(
-            ScmpCompareOp::from_str("SCMP_CMP_LT").unwrap().to_native(),
-            ScmpCompareOp::Less.to_native()
+            ScmpCompareOp::from_str("SCMP_CMP_LT").unwrap().to_sys(),
+            ScmpCompareOp::Less.to_sys()
         );
         assert_eq!(
-            ScmpCompareOp::from_str("SCMP_CMP_LE").unwrap().to_native(),
-            ScmpCompareOp::LessOrEqual.to_native()
+            ScmpCompareOp::from_str("SCMP_CMP_LE").unwrap().to_sys(),
+            ScmpCompareOp::LessOrEqual.to_sys()
         );
         assert_eq!(
-            ScmpCompareOp::from_str("SCMP_CMP_EQ").unwrap().to_native(),
-            ScmpCompareOp::Equal.to_native()
+            ScmpCompareOp::from_str("SCMP_CMP_EQ").unwrap().to_sys(),
+            ScmpCompareOp::Equal.to_sys()
         );
         assert_eq!(
-            ScmpCompareOp::from_str("SCMP_CMP_GE").unwrap().to_native(),
-            ScmpCompareOp::GreaterEqual.to_native()
+            ScmpCompareOp::from_str("SCMP_CMP_GE").unwrap().to_sys(),
+            ScmpCompareOp::GreaterEqual.to_sys()
         );
         assert_eq!(
-            ScmpCompareOp::from_str("SCMP_CMP_GT").unwrap().to_native(),
-            ScmpCompareOp::Greater.to_native()
+            ScmpCompareOp::from_str("SCMP_CMP_GT").unwrap().to_sys(),
+            ScmpCompareOp::Greater.to_sys()
         );
         assert_eq!(
             ScmpCompareOp::from_str("SCMP_CMP_MASKED_EQ")
                 .unwrap()
-                .to_native(),
-            ScmpCompareOp::MaskedEqual.to_native()
+                .to_sys(),
+            ScmpCompareOp::MaskedEqual.to_sys()
         );
         assert!(ScmpCompareOp::from_str("SCMP_INVALID_FLAG").is_err());
         assert_eq!(
             ScmpAction::from_str("SCMP_ACT_KILL_PROCESS", None)
                 .unwrap()
-                .to_native(),
-            ScmpAction::KillProcess.to_native()
+                .to_sys(),
+            ScmpAction::KillProcess.to_sys()
         );
         assert_eq!(
             ScmpAction::from_str("SCMP_ACT_ERRNO", Some(10))
                 .unwrap()
-                .to_native(),
-            ScmpAction::Errno(10).to_native()
+                .to_sys(),
+            ScmpAction::Errno(10).to_sys()
         );
         assert_eq!(
             ScmpAction::from_str("SCMP_ACT_TRACE", Some(10))
                 .unwrap()
-                .to_native(),
-            ScmpAction::Trace(10).to_native()
+                .to_sys(),
+            ScmpAction::Trace(10).to_sys()
         );
         assert_eq!(
-            ScmpArch::from_str("SCMP_ARCH_X86_64").unwrap().to_native(),
-            ScmpArch::X8664.to_native()
+            ScmpArch::from_str("SCMP_ARCH_X86_64").unwrap().to_sys(),
+            ScmpArch::X8664.to_sys()
         );
     }
 
@@ -989,7 +987,7 @@ mod tests {
 
         let action = ctx.get_filter_attr(ScmpFilterAttr::ActDefault).unwrap();
 
-        let expected_action: u32 = ScmpAction::Allow.to_native();
+        let expected_action: u32 = ScmpAction::Allow.to_sys();
 
         assert_eq!(expected_action, action);
     }


### PR DESCRIPTION
Rename get_native_arch() to ScmpAction::native() and keep it as
deprecated alias.

Unresolved:
- native() -- get native arch
- to_native()/from_native() -- ex/import from/to libseccomp-sys types

are two different kinds of "native". Maybe it is worth to rename
to_native to to_raw or to_sys?