### PR TITLE
export_{pfc,bpf} take a &mut T where T: AsRawFd

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -51,7 +51,6 @@ use error::{Result, SeccompError};
 use libseccomp_sys::*;
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
-use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::ptr::NonNull;
 
@@ -617,7 +616,7 @@ impl ScmpFilterContext {
     ///
     /// Accepts file to write to (must be open for writing).
     /// Returns an error if writing to the file fails.
-    pub fn export_pfc(&self, fd: File) -> Result<()> {
+    pub fn export_pfc<T: AsRawFd>(&self, fd: &mut T) -> Result<()> {
         let ret = unsafe { seccomp_export_pfc(self.ctx.as_ptr(), fd.as_raw_fd()) };
         if ret < 0 {
             return Err(SeccompError::new(Errno(ret)));
@@ -631,7 +630,7 @@ impl ScmpFilterContext {
     ///
     /// Accepts file to write to (must be open for writing).
     /// Returns an error if writing to the file fails.
-    pub fn export_bpf(&self, fd: File) -> Result<()> {
+    pub fn export_bpf<T: AsRawFd>(&self, fd: &mut T) -> Result<()> {
         let ret = unsafe { seccomp_export_bpf(self.ctx.as_ptr(), fd.as_raw_fd()) };
         if ret < 0 {
             return Err(SeccompError::new(Errno(ret)));


### PR DESCRIPTION
Taking ownership of the output file is bad if you want to do something
with the output (e.g. display to the user or pass to an other program).
Usually you would use `export_bpf(file.try_clone()?)?` to workaround
this. (OT: And remeber to `file.rewind()?`)
However I think it is save to take a &mut.

Using T: AsRawFd instead of file allows to pass types like ChildStdout
as well.

In the future (when io_safety is stabelized), we can change this to take
BorrowedFd.

---

This PR is an alternative to #29.