### PR TITLE
Fix memory leak in get_syscall_name_from_arch

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -775,11 +775,11 @@ pub fn get_syscall_name_from_arch(arch: ScmpArch, syscall_num: i32) -> Result<St
         ))));
     }
 
-    let name_c: &CStr = unsafe { CStr::from_ptr(ret) };
-    let name = name_c
+    let name = unsafe { CStr::from_ptr(ret) }
         .to_str()
         .map_err(|e: std::str::Utf8Error| SeccompError::with_source(Common(e.to_string()), e))?
         .to_string();
+    unsafe { libc::free(ret as *mut libc::c_void) };
 
     Ok(name)
 }


### PR DESCRIPTION
man 3 seccomp_syscall_resolve_num_arch:

> In the case of seccomp_syscall_resolve_num_arch() the associated syscall name
> is returned and it remains the callers responsibility to free the returned
> string via free(3).