### PR TITLE
Add static link test

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,9 +6,11 @@ runs:
   - run: sudo apt-get install gperf
     shell: bash
   - run: |
-      curl -sSLO https://github.com/seccomp/libseccomp/releases/download/v2.5.1/libseccomp-2.5.1.tar.gz
-      tar xvf libseccomp-2.5.1.tar.gz
-      pushd libseccomp-2.5.1
+      LIBSECCOMP_VERSION="2.5.1"
+      curl -sSLO "https://github.com/seccomp/libseccomp/releases/download/v${LIBSECCOMP_VERSION}\
+      /libseccomp-${LIBSECCOMP_VERSION}.tar.gz"
+      tar xvf "libseccomp-${LIBSECCOMP_VERSION}.tar.gz"
+      pushd "libseccomp-${LIBSECCOMP_VERSION}"
       ./configure
       make
       sudo make install

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -52,6 +52,23 @@ jobs:
       - name: Run test
         run: make test
 
+  static-link:
+    name: Static-link Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install upstream libseccomp
+        uses: ./.github/actions/setup
+      - name: Set environment variables
+        run: |
+          export LIBSECCOMP_LINK_TYPE=static
+          export LIBSECCOMP_LIB_PATH=/usr/local/lib
+      - name: Build crate
+        run: make build
+      - name: Run test
+        run: make test
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR contains two changes.

1. Refactor libseccomp install action
   - Make `LIBSECCOMP_VERSION` variable to make it easier to change the version
1. Add static link check to CI
   -  Currently, `libseccomp-rs` supports statically linking with libseccomp library, so run the test by CI.