### PR TITLE
ci/scripts: Run build/test against each libseccomp version 

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -24,11 +24,15 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        libseccomp-version: [2.4.3, 2.5.1, 2.5.3]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh
+        run: sudo ./scripts/install_libseccomp.sh -v ${{ matrix.libseccomp-version }}
       - name: Build crate
         run: make debug
       - name: Run test
@@ -54,7 +58,9 @@ jobs:
     name: Static-link Check for musl libc
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        libseccomp-version: [2.4.3, 2.5.1, 2.5.3]
         target:
           - x86_64-unknown-linux-musl
     env:
@@ -70,7 +76,7 @@ jobs:
       - name: Install upstream libseccomp
         run: |
           install_dir=$(dirname ${{ env.LIBSECCOMP_LIB_PATH }})
-          sudo ./scripts/install_libseccomp.sh -m -i ${install_dir}
+          sudo ./scripts/install_libseccomp.sh -m -v ${{ matrix.libseccomp-version }} -i ${install_dir}
       - name: Build crate
         run: cargo build --target ${{ matrix.target }}
       - name: Run test

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -38,24 +38,8 @@ jobs:
       - name: Run test
         run: make test
 
-  static-link-gnu:
-    name: Static-link Check for GNU libc
-    runs-on: ubuntu-latest
-    env:
-      LIBSECCOMP_LINK_TYPE: static
-      LIBSECCOMP_LIB_PATH: /usr/local/lib
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh
-      - name: Build crate
-        run: make build
-      - name: Run test
-        run: make test
-
   static-link-musl:
-    name: Static-link Check for musl libc
+    name: Statically Linking with musl
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -6,8 +6,23 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 jobs:
-  build:
-    name: Build
+  validate:
+    name: Format and Lint Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install upstream libseccomp
+        run: sudo ./scripts/install_libseccomp.sh
+      - name: Prepare for rustfmt and clippy
+        run: rustup component add rustfmt clippy
+      - name: Run rustfmt
+        run: make fmt
+      - name: Run clippy
+        run: make clippy
+
+  test:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,39 +31,6 @@ jobs:
         run: sudo ./scripts/install_libseccomp.sh
       - name: Build crate
         run: make debug
-
-  fmt:
-    name: Format Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Prepare for rustfmt
-        run: rustup component add rustfmt
-      - name: Run rustfmt
-        run: make fmt
-
-  clippy:
-    name: Clippy Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh
-      - name: Prepare for clippy
-        run: rustup component add clippy
-      - name: run clippy
-        run: make clippy
-
-  test:
-    name: Unit Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh
       - name: Run test
         run: make test
 

--- a/scripts/install_libseccomp.sh
+++ b/scripts/install_libseccomp.sh
@@ -7,27 +7,22 @@
 
 set -o errexit
 
-work_dir="$(mktemp -d --tmpdir build-libseccomp.XXXXX)"
-
-# Variables for libseccomp
-libseccomp_version="2.5.1"
-libseccomp_url="https://github.com/seccomp/libseccomp"
-libseccomp_tarball="libseccomp-${libseccomp_version}.tar.gz"
-libseccomp_tarball_url="${libseccomp_url}/releases/download/v${libseccomp_version}/${libseccomp_tarball}"
-
-# Variables for gperf
-gperf_version="3.1"
-gperf_url="https://ftp.gnu.org/gnu/gperf"
-gperf_tarball="gperf-${gperf_version}.tar.gz"
-gperf_tarball_url="${gperf_url}/${gperf_tarball}"
+# installed libseccomp version by default
+DEFAULT_LIBSECCOMP_VER="2.5.3"
+WORK_DIR="$(mktemp -d --tmpdir build-libseccomp.XXXXX)"
 
 function finish() {
-    rm -rf "${work_dir}"
+    rm -rf "${WORK_DIR}"
 }
 
 trap finish EXIT
 
 function build_and_install_gperf() {
+    gperf_version="3.1"
+    gperf_url="https://ftp.gnu.org/gnu/gperf"
+    gperf_tarball="gperf-${gperf_version}.tar.gz"
+    gperf_tarball_url="${gperf_url}/${gperf_tarball}"
+
     echo "Build and install gperf version ${gperf_version}"
     gperf_install_dir="$(mktemp -d --tmpdir build-gperf.XXXXX)"
     curl -sLO "${gperf_tarball_url}"
@@ -42,6 +37,11 @@ function build_and_install_gperf() {
 }
 
 function build_and_install_libseccomp() {
+    libseccomp_version=${opt_ver}
+    libseccomp_url="https://github.com/seccomp/libseccomp"
+    libseccomp_tarball="libseccomp-${libseccomp_version}.tar.gz"
+    libseccomp_tarball_url="${libseccomp_url}/releases/download/v${libseccomp_version}/${libseccomp_tarball}"
+
     echo "Build and install libseccomp version ${libseccomp_version}"
     libseccomp_install_dir=$opt_dir
     mkdir -p "${libseccomp_install_dir}"
@@ -69,26 +69,31 @@ cat <<EOF
 Build and install libseccomp library from sources
 
 USAGE:
-  install_libseccomp [-m] [-i DIR]
+  install_libseccomp [-m] [-v VERSION] [-i DIR]
 
 OPTIONS:
-  -h        : show this help message
-  -m        : install libseccomp library for musl-libc [default: GNU-libc]
-  -i [DIR]  : specify the directory for installing libseccomp library [default: /usr/local]
+  -h            : show this help message
+  -m            : install libseccomp library for musl-libc [default: GNU-libc]
+  -v [VERSION]  : specify the version of installed libseccomp library [default: ${DEFAULT_LIBSECCOMP_VER}]
+  -i [DIR]      : specify the directory for installing libseccomp library [default: /usr/local]
 EOF
 }
 
 function main() {
+    local opt_ver=${DEFAULT_LIBSECCOMP_VER}
     local opt_musl=0
     local opt_dir="/usr/local"
 
-    while getopts "hmi:" opt; do
+    while getopts "hmi:v:" opt; do
         case $opt in
             m)
                 opt_musl=1
                 ;;
             i)
                 opt_dir="${OPTARG}"
+                ;;
+            v)
+                opt_ver="${OPTARG}"
                 ;;
             h|*)
                 usage
@@ -97,10 +102,7 @@ function main() {
         esac
     done
 
-    echo "${opt_musl}"
-    echo "${opt_dir}"
-
-    pushd "${work_dir}"
+    pushd "${WORK_DIR}"
     # gperf is required for building the libseccomp.
     build_and_install_gperf
     build_and_install_libseccomp


### PR DESCRIPTION
This PR has the following two commits.

1. ci/scripts: Run build/test against each libseccomp version 
   - Do compile and test against the `2.4.3`, `2.5.1`, and `2.5.3` that is the latest released version.
   - Modify `install_libseccomp.sh` to be able to install arbitrary libseccomp version specified by the option(-v)
1. Combine jobs in CI
   - Combine fmt and clippy check
   - Combine build and unit test