### PR TITLE
CI: Link the libseccomp library compiled by our script

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,11 +28,17 @@ jobs:
       fail-fast: false
       matrix:
         libseccomp-version: [2.4.3, 2.5.1, 2.5.3]
+    env:
+      LIBSECCOMP_LINK_TYPE: dylib
+      LIBSECCOMP_LIB_PATH: /usr/local/libseccomp/lib
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh -v ${{ matrix.libseccomp-version }}
+        run: |
+          install_dir=$(dirname ${{ env.LIBSECCOMP_LIB_PATH }})
+          sudo ./scripts/install_libseccomp.sh -v ${{ matrix.libseccomp-version }} -i ${install_dir}
+          echo "LD_LIBRARY_PATH=${{ env.LIBSECCOMP_LIB_PATH }}" >> $GITHUB_ENV
       - name: Build crate
         run: make debug
       - name: Run test

--- a/libseccomp/build.rs
+++ b/libseccomp/build.rs
@@ -3,7 +3,17 @@
 // Copyright 2021 Sony Group Corporation
 //
 
+use std::{env, path};
+
 fn main() {
+    println!("cargo:rerun-if-env-changed=LIBSECCOMP_LIB_PATH");
+
+    if let Ok(path) = env::var("LIBSECCOMP_LIB_PATH") {
+        println!("cargo:rustc-link-search=native={}", path);
+        let pkgconfig = path::Path::new(&path).join("pkgconfig");
+        env::set_var("PKG_CONFIG_PATH", pkgconfig);
+    }
+
     if pkg_config::Config::new()
         .atleast_version("2.5.0")
         .probe("libseccomp")


### PR DESCRIPTION
In order to use the libseccomp library installed by our script,
not the library in Ubuntu image of GiHub Actions, we install the
libseccomp library for dynamically linking against gnu-libc into
specified directory. Then, link the complied library forcibly using LD_LIBRARY_PATH.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>