### PR TITLE
ci: Switch to mirror server for gnu.org

### DIFF
--- a/scripts/install_libseccomp.sh
+++ b/scripts/install_libseccomp.sh
@@ -19,7 +19,7 @@ trap finish EXIT
 
 function build_and_install_gperf() {
     gperf_version="3.1"
-    gperf_url="https://ftp.gnu.org/gnu/gperf"
+    gperf_url="https://mirrors.kernel.org/gnu/gperf"
     gperf_tarball="gperf-${gperf_version}.tar.gz"
     gperf_tarball_url="${gperf_url}/${gperf_tarball}"
 


### PR DESCRIPTION
Currently, CI jobs are failing because www.gnu.org is down.
So, we switch to the mirror server.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>