### PR TITLE
Remove tool/target in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
-/tool/target
 Cargo.lock


### PR DESCRIPTION
The `tool` directory was removed by #36.
Hence, we remove `tool/target` in `.gitignore`.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>