### PR TITLE
Add SPDX and Copyright to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0 or MIT
+#
+# Copyright 2021 Sony Group Corporation
+#
+
 all: build fmt test
 
 #


### PR DESCRIPTION
Add SPDX license identifier and Copyright to `Makefile`.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>