### PR TITLE
Make the format of doc comments consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,21 @@ Create and load a single seccomp rule:
 use libseccomp::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // new_filter creates and returns a new filter context.
+    // Creates and returns a new filter context.
     let mut filter = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
 
-    // add_arch adds an architecture to the filter.
+    // Adds an architecture to the filter.
     filter.add_arch(ScmpArch::X8664)?;
 
-    // get_syscall_from_name returns the number of a syscall by name for a given
-    // architectures's ABI.
+    // Returns the number of a syscall by name for a given architectures's ABI.
     // If arch argument is None, the function returns the number of a syscall
     // on the kernel's native architecture.
     let syscall = get_syscall_from_name("dup3", None)?;
 
-    // add_rule adds a single rule for an unconditional action on a syscall.
+    // Adds a single rule for an unconditional action on the syscall.
     filter.add_rule(ScmpAction::Errno(10), syscall)?;
 
-    // load loads the filter context into the kernel.
+    // Loads the filter context into the kernel.
     filter.load()?;
 
     // The dup3 fails by the seccomp rule.

--- a/libseccomp/src/error.rs
+++ b/libseccomp/src/error.rs
@@ -11,7 +11,7 @@ use std::fmt;
 const EACCES: &str = "Setting the attribute with the given value is not allowed";
 const ECANCELED: &str = "There was a system failure beyond the control of libseccomp";
 const EDOM: &str = "Architecture specific failure";
-const EEXIST: &str = "Failure regrading the existance of argument";
+const EEXIST: &str = "Failure regrading the existence of argument";
 const EFAULT: &str = "Internal libseccomp failure";
 const EINVAL: &str = "Invalid input to the libseccomp API";
 const ENOENT: &str = "No matching entry found";
@@ -23,16 +23,21 @@ const ESRCH: &str = "Unable to load the filter due to thread issues";
 // ParseError message
 const PARSE_ERROR: &str = "Parse error by invalid argument";
 
-/// The different types of errors that can occur while manipulating libseccomp api.
+/// A list specifying different categories of error.
 #[derive(Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ErrorKind {
+    /// An error that represents error code on failure of the libseccomp API.
     Errno(i32),
-    Common(String),
+    /// A parse error occurred while trying to convert a value.
     ParseError,
+    /// A lower-level error that is caused by an error from a lower-level module.
     Source,
+    /// A custom error that does not fall under any other error kind.
+    Common(String),
 }
 
+/// The error type for libseccomp operations.
 pub struct SeccompError {
     kind: ErrorKind,
     source: Option<Box<dyn Error + Send + Sync>>,


### PR DESCRIPTION
Currently, the format of doc comments is not consistent.
Hence, this commit decides the format as follows in the crate.
This format is based on https://doc.rust-lang.org/rust-by-example/meta/doc.html

The doc comments of function:
```
/// Brief summary of the function on one line. (Start from "verb-s")
///
/// Detailed description of the function. (if you have)
///
/// Description of return value on success.
/// (Start from "This function returns...")
///
/// # Arguments (if the function has arguments)
///
/// * `arg` - Descripition of the argument
///
/// # Errors (if the function returns `Result`)
///
///  If this function encounters..., an error will be returned.
///
/// # Panics (if the function can `panic`)
///
///  Panics if...
///
/// # Examples (if you want to show the example)
///
/// ```
/// Example codes
/// ```
pub fn foo
```

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>