### PR TITLE
Make the notify module visible in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fixed docs.rs build to make the `notify` module visible in the documentations.
 
 ### Removed
 

--- a/libseccomp/Cargo.toml
+++ b/libseccomp/Cargo.toml
@@ -16,3 +16,6 @@ libseccomp-sys = { version = "0.2.0", path = "../libseccomp-sys" }
 
 [build-dependencies]
 pkg-config = "0.3.19"
+
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -47,7 +47,7 @@
 //! ```
 
 pub mod error;
-#[cfg(libseccomp_v2_5)]
+#[cfg(any(libseccomp_v2_5, docsrs))]
 pub mod notify;
 
 use error::ErrorKind::*;


### PR DESCRIPTION
Fix docs.rs build to make the notify module visible in the documentations.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>