### PR TITLE
Make the notify module visible in the docs using doc_cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Re-fixed docs.rs build to make the `notify` module visible in the documentations by `doc_cfg`
+feature.
 
 ### Removed
 

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -46,8 +46,10 @@
 //! }
 //! ```
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod error;
-#[cfg(any(libseccomp_v2_5, docsrs))]
+#[cfg(any(libseccomp_v2_5, doc))]
 pub mod notify;
 
 use error::ErrorKind::*;


### PR DESCRIPTION
Re-fix docs.rs build to make the notify module visible
in the documentations using `doc_cfg` feature.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>