### PR TITLE
gitignore: Cover all target directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target/
 Cargo.lock


### PR DESCRIPTION
This also ignores libseccomp/target and libseccomp-sys/target