### PR TITLE
Add "SCMP_ARCH_MIPS64N32" to ScmpArch::from_str()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- `"SCMP_ARCH_MIPS64N32"` to `ScmpArch::from_str()`.
 
 ### Changed
 

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -635,6 +635,7 @@ impl std::str::FromStr for ScmpArch {
             "SCMP_ARCH_AARCH64" => Ok(Self::Aarch64),
             "SCMP_ARCH_MIPS" => Ok(Self::Mips),
             "SCMP_ARCH_MIPS64" => Ok(Self::Mips64),
+            "SCMP_ARCH_MIPS64N32" => Ok(Self::Mips64N32),
             "SCMP_ARCH_MIPSEL" => Ok(Self::Mipsel),
             "SCMP_ARCH_MIPSEL64" => Ok(Self::Mipsel64),
             "SCMP_ARCH_MIPSEL64N32" => Ok(Self::Mipsel64N32),


### PR DESCRIPTION
`ScmpArch::from_str()` supports for converting `"SCMP_ARCH_MIPS64N32"`
string into `ScmpArch`.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>