### PR TITLE
Add {get,set}_badarch_action function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - `"SCMP_ARCH_MIPS64N32"` to `ScmpArch::from_str()`.
+- `ScmpFilterContext::{get,set}_badarch_action()` to get/set the default action taken on a syscall for
+an architecture not in the filter.
 
 ### Changed
 


### PR DESCRIPTION
This commit adds the following two functions

- `get_badarch_action()` to get the default action taken when the
loaded filter does not match the architecture  of the executing application.
- `set_badarch_action()` to set the default action taken when the
loaded filter does not match the architecture  of the executing application.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>