### PR TITLE
Fix misleading example

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let mut filter = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-//!     let syscall = get_syscall_from_name("dup3", Some(ScmpArch::X8664))?;
+//!     let syscall = get_syscall_from_name("dup3", None)?;
 //!     let cmp = ScmpArgCompare::new(0, ScmpCompareOp::Equal, 1);
 //!
 //!     filter.add_arch(ScmpArch::X8664)?;


### PR DESCRIPTION
seccomp_syscall_resolve_name_arch resolves the given syscall name to the
syscall number (or pseudo number) it has on the give architectur.
If you are not running on this archtecture, the result isn't the native
number of the syscall.

seccomp_rule_add interprets the given syscall number for the native
archtecture. Passing a number resolved for a foreign architecture, gives
you any result but not what you want. In the best case this number is
invalid for you native architecture and a error is returend, but it is
also possible that the number is valid, then the blocked syscall is any
arbitrary syscall.

Signed-off-by: rusty-snake <41237666+rusty-snake@users.noreply.github.com>