### PR TITLE
api: Add get_default_action()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `"SCMP_ARCH_MIPS64N32"` to `ScmpArch::from_str()`.
 - `ScmpFilterContext::{get,set}_badarch_action()` to get/set the default action taken on a syscall for
 an architecture not in the filter.
+- `ScmpFilterContext::get_default_action()` to get the default action as specified in the call to
+`new_filter()` or `reset()`.
 - `reset_global_state()` to reset libseccomp's global state.
 - `derive(Hash)` for the most types
 - `ScmpSyscall` type

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -1257,6 +1257,29 @@ impl ScmpFilterContext {
         Ok(attribute)
     }
 
+    /// Gets the default action as specified in the call to
+    /// [`new_filter()`](ScmpFilterContext::new_filter) or [`reset()`](ScmpFilterContext::reset).
+    ///
+    /// # Errors
+    ///
+    /// If this function is called with an invalid filter or an issue is
+    /// encountered getting the action, an error will be returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use libseccomp::*;
+    /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
+    /// let action = ctx.get_default_action()?;
+    /// assert_eq!(action, ScmpAction::Allow);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn get_default_action(&self) -> Result<ScmpAction> {
+        let ret = self.get_filter_attr(ScmpFilterAttr::ActDefault)?;
+
+        ScmpAction::from_sys(ret)
+    }
+
     /// Gets the default action taken when the loaded filter does not match the architecture
     /// of the executing application.
     ///
@@ -1934,6 +1957,10 @@ mod tests {
             let ret = ctx.get_badarch_action().unwrap();
             assert_eq!(ret, action);
         }
+
+        // Test for ActDefault
+        let ret = ctx.get_default_action().unwrap();
+        assert_eq!(ret, ScmpAction::KillThread);
     }
 
     #[test]


### PR DESCRIPTION
Add `get_default_action()` to get the default action as specified in the
call to `new_filter()` or `reset()`.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>