### PR TITLE
Add #[must_use] to some function in libseccomp

### DIFF
--- a/libseccomp-sys/src/lib.rs
+++ b/libseccomp-sys/src/lib.rs
@@ -237,11 +237,13 @@ pub const SCMP_ACT_TRAP: u32 = 0x00030000;
 pub const SCMP_ACT_NOTIFY: u32 = 0x7fc00000;
 pub const SCMP_ACT_ERRNO_MASK: u32 = 0x00050000;
 /// Return the specified error code
+#[must_use]
 pub const fn SCMP_ACT_ERRNO(x: u16) -> u32 {
     SCMP_ACT_ERRNO_MASK | x as u32
 }
 pub const SCMP_ACT_TRACE_MASK: u32 = 0x7ff00000;
 /// Notify a tracing process with the specified value
+#[must_use]
 pub const fn SCMP_ACT_TRACE(x: u16) -> u32 {
     SCMP_ACT_TRACE_MASK | x as u32
 }

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -287,6 +287,7 @@ impl ScmpArgCompare {
     /// * `arg` - The number of the argument
     /// * `op` - A comparison operator
     /// * `datum` - A value to compare to
+    #[must_use]
     pub const fn new(arg: u32, op: ScmpCompareOp, datum: u64) -> Self {
         if let ScmpCompareOp::MaskedEqual(mask) = op {
             Self(scmp_arg_cmp {
@@ -1431,6 +1432,7 @@ impl ScmpFilterContext {
     /// Gets a raw pointer of a seccomp filter.
     ///
     /// This function return a raw pointer to the [`scmp_filter_ctx`].
+    #[must_use]
     pub fn as_ptr(&self) -> scmp_filter_ctx {
         self.ctx.as_ptr()
     }

--- a/libseccomp/src/notify.rs
+++ b/libseccomp/src/notify.rs
@@ -204,6 +204,7 @@ impl ScmpNotifResp {
     /// * `val` - Return value for the syscall that created the notification
     /// * `error` - An error code
     /// * `flags` - Userspace notification response flag
+    #[must_use]
     pub fn new(id: u64, val: i64, error: i32, flags: u32) -> Self {
         Self {
             id,


### PR DESCRIPTION
This adds #[must_use] to all functions in libseccomp suggested by

    cargo clippy -- --warn clippy::must_use_candidate

Signed-off-by: rusty-snake <41237666+rusty-snake@users.noreply.github.com>