### PR TITLE
api: Rename {get,set}_badarch_action to {get,set}_act_badarch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - `"SCMP_ARCH_MIPS64N32"` to `ScmpArch::from_str()`.
-- `ScmpFilterContext::{get,set}_badarch_action()` to get/set the default action taken on a syscall for
+- `ScmpFilterContext::{get,set}_act_badarch()` to get/set the default action taken on a syscall for
 an architecture not in the filter.
 - `ScmpFilterContext::get_default_action()` to get the default action as specified in the call to
 `new_filter()` or `reset()`.

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -1293,11 +1293,11 @@ impl ScmpFilterContext {
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-    /// let action = ctx.get_badarch_action()?;
+    /// let action = ctx.get_act_badarch()?;
     /// assert_eq!(action, ScmpAction::KillThread);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn get_badarch_action(&self) -> Result<ScmpAction> {
+    pub fn get_act_badarch(&self) -> Result<ScmpAction> {
         let ret = self.get_filter_attr(ScmpFilterAttr::ActBadArch)?;
 
         ScmpAction::from_sys(ret)
@@ -1364,10 +1364,10 @@ impl ScmpFilterContext {
     ///  ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-    /// ctx.set_badarch_action(ScmpAction::KillProcess)?;
+    /// ctx.set_act_badarch(ScmpAction::KillProcess)?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn set_badarch_action(&mut self, action: ScmpAction) -> Result<()> {
+    pub fn set_act_badarch(&mut self, action: ScmpAction) -> Result<()> {
         self.set_filter_attr(ScmpFilterAttr::ActBadArch, action.to_sys())
     }
 
@@ -1953,8 +1953,8 @@ mod tests {
             ScmpAction::Trace(10),
         ];
         for action in test_actions {
-            ctx.set_badarch_action(action).unwrap();
-            let ret = ctx.get_badarch_action().unwrap();
+            ctx.set_act_badarch(action).unwrap();
+            let ret = ctx.get_act_badarch().unwrap();
             assert_eq!(ret, action);
         }
 


### PR DESCRIPTION
Rename `{get,set}_badarch_action` function to `{get,set}_act_badarch`.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>