### PR TITLE
api: Rename get_default_action to get_act_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `"SCMP_ARCH_MIPS64N32"` to `ScmpArch::from_str()`.
 - `ScmpFilterContext::{get,set}_badarch_action()` to get/set the default action taken on a syscall for
 an architecture not in the filter.
-- `ScmpFilterContext::get_default_action()` to get the default action as specified in the call to
+- `ScmpFilterContext::get_act_default()` to get the default action as specified in the call to
 `new_filter()` or `reset()`.
 - `reset_global_state()` to reset libseccomp's global state.
 - `derive(Hash)` for the most types

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -1270,11 +1270,11 @@ impl ScmpFilterContext {
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-    /// let action = ctx.get_default_action()?;
+    /// let action = ctx.get_act_default()?;
     /// assert_eq!(action, ScmpAction::Allow);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn get_default_action(&self) -> Result<ScmpAction> {
+    pub fn get_act_default(&self) -> Result<ScmpAction> {
         let ret = self.get_filter_attr(ScmpFilterAttr::ActDefault)?;
 
         ScmpAction::from_sys(ret)
@@ -1959,7 +1959,7 @@ mod tests {
         }
 
         // Test for ActDefault
-        let ret = ctx.get_default_action().unwrap();
+        let ret = ctx.get_act_default().unwrap();
         assert_eq!(ret, ScmpAction::KillThread);
     }
 


### PR DESCRIPTION
Rename `get_default_action` function to `get_act_default`.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>