### PR TITLE
Add ScmpFilterContext::{get,set}_ctl_ssb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ an architecture not in the filter.
 - `ScmpFilterContext::get_ctl_nnp` (replaces `ScmpFilterContext::get_no_new_privs_bit`).
 - `ScmpFilterContext::set_ctl_nnp` (replaces `ScmpFilterContext::set_no_new_privs_bit`).
 - `ScmpFilterContext::{get,set}_ctl_log()` to get/set the state of the `ScmpFilterAttr::CtlLog`.
+- `ScmpFilterContext::{get,set}_ctl_ssb()` to get/set the state of the `ScmpFilterAttr::CtlSsb`.
 - `reset_global_state()` to reset libseccomp's global state.
 - `derive(Hash)` for the most types
 - `ScmpSyscall` type


### PR DESCRIPTION
Add `ScmpFilterContext::{get,set}_ctl_ssb()` to get/set the state of
`ScmpFilterAttr::CtlSsb` attribute.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>