### PR TITLE
Add ScmpFilterContext::{get,set}_ctl_tsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ an architecture not in the filter.
 - `ScmpFilterContext::{get,set}_ctl_ssb()` to get/set the state of the `ScmpFilterAttr::CtlSsb`.
 - `ScmpFilterContext::{get,set}_ctl_optimize()` to get/set the level of the `ScmpFilterAttr::CtlOptimize`.
 - `ScmpFilterContext::{get,set}_api_sysrawrc()` to get/set the state of the `ScmpFilterAttr::ApiSysRawRc`.
+- `ScmpFilterContext::{get,set}_ctl_tsync()` to get/set the state of the `ScmpFilterAttr::CtlTsync`.
 - `reset_global_state()` to reset libseccomp's global state.
 - `derive(Hash)` for the most types
 - `ScmpSyscall` type


### PR DESCRIPTION
Add `ScmpFilterContext::{get,set}_ctl_tsync()` to get/set the state of
`ScmpFilterAttr::CtlTsync` attribute.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>