### PR TITLE
build: Use const variable for LIBSECCOMP_{LINK_TYPE,LIB_PATH}

### DIFF
--- a/libseccomp-sys/build.rs
+++ b/libseccomp-sys/build.rs
@@ -5,15 +5,18 @@
 
 use std::env;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-env-changed=LIBSECCOMP_LIB_PATH");
-    println!("cargo:rerun-if-env-changed=LIBSECCOMP_LINK_TYPE");
+const LIBSECCOMP_LIB_PATH: &str = "LIBSECCOMP_LIB_PATH";
+const LIBSECCOMP_LINK_TYPE: &str = "LIBSECCOMP_LINK_TYPE";
 
-    if let Ok(path) = env::var("LIBSECCOMP_LIB_PATH") {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed={}", LIBSECCOMP_LIB_PATH);
+    println!("cargo:rerun-if-env-changed={}", LIBSECCOMP_LINK_TYPE);
+
+    if let Ok(path) = env::var(LIBSECCOMP_LIB_PATH) {
         println!("cargo:rustc-link-search=native={}", path);
     }
 
-    let link_type = match env::var("LIBSECCOMP_LINK_TYPE") {
+    let link_type = match env::var(LIBSECCOMP_LINK_TYPE) {
         Ok(link_type) if link_type == "framework" => {
             return Err("Seccomp is a Linux specific technology".into());
         }

--- a/libseccomp/build.rs
+++ b/libseccomp/build.rs
@@ -5,10 +5,12 @@
 
 use std::{env, path};
 
-fn main() {
-    println!("cargo:rerun-if-env-changed=LIBSECCOMP_LIB_PATH");
+const LIBSECCOMP_LIB_PATH: &str = "LIBSECCOMP_LIB_PATH";
 
-    if let Ok(path) = env::var("LIBSECCOMP_LIB_PATH") {
+fn main() {
+    println!("cargo:rerun-if-env-changed={}", LIBSECCOMP_LIB_PATH);
+
+    if let Ok(path) = env::var(LIBSECCOMP_LIB_PATH) {
         println!("cargo:rustc-link-search=native={}", path);
         let pkgconfig = path::Path::new(&path).join("pkgconfig");
         env::set_var("PKG_CONFIG_PATH", pkgconfig);


### PR DESCRIPTION
Use const variable for `LIBSECCOMP_LINK_TYPE` and
`LIBSECCOMP_LIB_PATH` environment variables.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>