### PR TITLE
build: Add "bundled" feature used in build script

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,13 +13,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh
+        run: |
+          sudo apt-get install gperf
+          sudo ./scripts/install_libseccomp.sh
       - name: Prepare for rustfmt and clippy
         run: rustup component add rustfmt clippy
       - name: Run rustfmt
         run: make fmt
       - name: Run clippy
         run: make clippy
+
+  test-install-script:
+    name: Test script to build and install gperf and libseccomp
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install upstream libseccomp
+        run: sudo ./scripts/install_libseccomp.sh
 
   test:
     name: Unit Tests
@@ -36,6 +47,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install upstream libseccomp
         run: |
+          sudo apt-get install gperf
           install_dir=$(dirname ${{ env.LIBSECCOMP_LIB_PATH }})
           sudo ./scripts/install_libseccomp.sh -v ${{ matrix.libseccomp-version }} -i ${install_dir}
           echo "LD_LIBRARY_PATH=${{ env.LIBSECCOMP_LIB_PATH }}" >> $GITHUB_ENV
@@ -65,12 +77,37 @@ jobs:
         run: sudo apt-get install musl-tools
       - name: Install upstream libseccomp
         run: |
+          sudo apt-get install gperf
           install_dir=$(dirname ${{ env.LIBSECCOMP_LIB_PATH }})
           sudo ./scripts/install_libseccomp.sh -m -v ${{ matrix.libseccomp-version }} -i ${install_dir}
       - name: Build crate
         run: cargo build --target ${{ matrix.target }}
       - name: Run test
         run: cargo test --target ${{ matrix.target }} -- --nocapture --test-threads 1
+
+  static-link-bundled:
+    # If we didn't target musl, we would have to use ldd or some other tool to
+    # manually check that seccomp isn't linked dynamically in a test program.
+    name: Statically Linking with musl and the bundled feature
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        run: rustup target add ${{ matrix.target }}
+      - name: Install musl gcc
+        run: sudo apt-get install musl-tools
+      - name: Install gperf
+        run: sudo apt-get install gperf
+      - name: Build crate
+        run: cargo build --features bundled --target ${{ matrix.target }}
+      - name: Run test
+        run: cargo test --features bundled --target ${{ matrix.target }} -- --nocapture --test-threads 1
 
   doc:
     name: Documentation Check
@@ -94,7 +131,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh
+        run: |
+          sudo apt-get install gperf
+          sudo ./scripts/install_libseccomp.sh
       - name: Run cargo tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- "bundled" feature to allow downloading and building libseccomp at build time.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ Now, add the following to your `Cargo.toml` to start building the libseccomp cra
 libseccomp = "0.2.3"
 ```
 
+### Building libseccomp with the `bundled` feature
+
+By enabling the bundled feature (see below), libseccomp-rs will automatically download, build, and link libseccomp for you. See the README for libseccomp-sys for more information.
+
+```toml
+[dependencies]
+libseccomp = { version = "0.2.3", features = ["bundled"] }
+```
+
 ## Testing the crate
 The libseccomp crate provides a number of unit tests.
 If you want to run the standard regression tests, you can execute the following command.

--- a/README.md
+++ b/README.md
@@ -108,14 +108,31 @@ Now, add the following to your `Cargo.toml` to start building the libseccomp cra
 libseccomp = "0.2.3"
 ```
 
-### Building libseccomp with the `bundled` feature
+### Building and statically linking the libseccomp library with the `bundled` feature
 
-By enabling the bundled feature (see below), libseccomp-rs will automatically download, build, and link libseccomp for you. See the README for libseccomp-sys for more information.
+By enabling the bundled feature (see below), libseccomp-rs will automatically
+download, build, and statically link libseccomp for you. See the README for
+libseccomp-sys for more information.
 
 ```toml
 [dependencies]
 libseccomp = { version = "0.2.3", features = ["bundled"] }
 ```
+
+The bundled feature downloads and builds the libseccomp sources according to
+the file
+[versions.rs](https://github.com/libseccomp-rs/libseccomp-rs/blob/main/libseccomp-sys/versions.rs)
+by default if the `LIBSECCOMP_SRC_PATH` environment variable is not set. If you
+want to use libseccomp source code you have locally on your system, set the
+`LIBSECCOMP_SRC_PATH` to specify the source path as follows.
+
+```shell
+$ export LIBSECCOMP_SRC_PATH="the path of the directory containing the libseccomp sources"
+```
+
+> **Note**: If you want to link the libseccomp library dynamically, you should not enable this feature.
+
+
 
 ## Testing the crate
 The libseccomp crate provides a number of unit tests.

--- a/libseccomp-sys/Cargo.toml
+++ b/libseccomp-sys/Cargo.toml
@@ -8,3 +8,12 @@ repository = "https://github.com/libseccomp-rs/libseccomp-rs"
 categories = ["seccomp", "api-bindings"]
 edition = "2018"
 readme = "README.md"
+
+[features]
+# Allows downloading and building libseccomp at build time.
+bundled = ["cc"]
+
+[build-dependencies]
+# Used to get compiler information to set CC and CFLAGS env variables when
+# compiling bundled libseccomp.
+cc = { version = "1.0.72", optional = true }

--- a/libseccomp-sys/README.md
+++ b/libseccomp-sys/README.md
@@ -14,8 +14,15 @@ Therefore most users should not need to interact with this crate directly.
 
 ## Optional features
 
-* `bundled`: Downloads and builds libseccomp for you. See below for version info. Additionally, several environment variables are available that affect the bundled feature - `LIBSECCOMP_LIB_PATH`, `LIBSECCOMP_LINK_TYPE`, `LIBSECCOMP_SRC_PATH`. See [build.rs](https://github.com/libseccomp-rs/libseccomp-rs/blob/main/libseccomp-sys/build.rs) for more information on how they're used.
+* `bundled`: Downloads, builds, and links the libseccomp library **statically**
+  for you. Regarding the installed libseccomp version, see below for version
+information. For more information on how this feature works, see the [README
+for the libseccomp
+crate](https://github.com/libseccomp-rs/libseccomp-rs#building-and-statically-linking-the-libseccomp-library-with-the-bundled-feature).
+
 
 ## Version information
 
-See the file [versions.rs](https://github.com/libseccomp-rs/libseccomp-rs/blob/main/libseccomp-sys/versions.rs). Other versions may be built by using the environment variables mentioned above.
+See the file
+[versions.rs](https://github.com/libseccomp-rs/libseccomp-rs/blob/main/libseccomp-sys/versions.rs).
+Other versions may be built by using the environment variables mentioned above.

--- a/libseccomp-sys/README.md
+++ b/libseccomp-sys/README.md
@@ -12,6 +12,10 @@ These low-level, mostly `unsafe` bindings are then used by the [libseccomp crate
 which wraps them in a nice to use, mostly safe API.
 Therefore most users should not need to interact with this crate directly.
 
+## Optional features
+
+* `bundled`: Downloads and builds libseccomp for you. See below for version info. Additionally, several environment variables are available that affect the bundled feature - `LIBSECCOMP_LIB_PATH`, `LIBSECCOMP_LINK_TYPE`, `LIBSECCOMP_SRC_PATH`. See [build.rs](https://github.com/libseccomp-rs/libseccomp-rs/blob/main/libseccomp-sys/build.rs) for more information on how they're used.
+
 ## Version information
 
-Currently, the libseccomp-sys supports libseccomp version 2.5.3.
+See the file [versions.rs](https://github.com/libseccomp-rs/libseccomp-rs/blob/main/libseccomp-sys/versions.rs). Other versions may be built by using the environment variables mentioned above.

--- a/libseccomp-sys/build.rs
+++ b/libseccomp-sys/build.rs
@@ -5,26 +5,239 @@
 
 use std::env;
 
+mod versions;
+
 const LIBSECCOMP_LIB_PATH: &str = "LIBSECCOMP_LIB_PATH";
 const LIBSECCOMP_LINK_TYPE: &str = "LIBSECCOMP_LINK_TYPE";
+const LIBSECCOMP_SRC_PATH: &str = "LIBSECCOMP_SRC_PATH";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-env-changed={}", LIBSECCOMP_SRC_PATH);
     println!("cargo:rerun-if-env-changed={}", LIBSECCOMP_LIB_PATH);
     println!("cargo:rerun-if-env-changed={}", LIBSECCOMP_LINK_TYPE);
 
-    if let Ok(path) = env::var(LIBSECCOMP_LIB_PATH) {
-        println!("cargo:rustc-link-search=native={}", path);
+    // We do cfg on blocks here instead of `if cfg!()...` so we don't have to build the cc library
+    // at all in the non-bundled case.
+
+    // If bundled feature is enabled, build the library and return any errors.
+    #[cfg(feature = "bundled")]
+    {
+        let lib_dir = build_bundled::build()?;
+        build_linked::link(Some(&lib_dir), Some("static"))
+    }
+    #[cfg(not(feature = "bundled"))]
+    {
+        // Otherwise, link with system library.
+        build_linked::link(None, None)
+    }
+}
+
+#[cfg(feature = "bundled")]
+mod build_bundled {
+    use super::*;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+
+    use super::versions::*;
+
+    /// Downloads (if `LIBSECCOMP_SRC_PATH` is not set) and builds the libseccomp source.
+    pub fn build() -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let out_dir =
+            PathBuf::from(env::var("OUT_DIR").expect("out dir always exists in build scripts"));
+        let lib_path = env::var(LIBSECCOMP_LIB_PATH);
+
+        // If lib path is set, skip build and use lib path directly.
+        if let Ok(path) = lib_path {
+            return Ok(PathBuf::from(path));
+        }
+
+        // Determine whether to download or not:
+        // If src is set, use it. Otherwise, download and set src path.
+        let src_path = if let Ok(path) = env::var(LIBSECCOMP_SRC_PATH) {
+            PathBuf::from(path)
+        } else {
+            download_libseccomp(out_dir.as_path())?
+        };
+
+        let mut build_output_path = build_libseccomp(&src_path, &out_dir)?;
+
+        // Return just the lib path from the build.
+        build_output_path.push("lib");
+
+        Ok(build_output_path)
     }
 
-    let link_type = match env::var(LIBSECCOMP_LINK_TYPE) {
-        Ok(link_type) if link_type == "framework" => {
-            return Err("Seccomp is a Linux specific technology".into());
+    /// Build source with configure, make, make install, setting the output directory to a
+    /// directory in our package's out_dir.
+    fn build_libseccomp(
+        src_path: &Path,
+        out_dir: &Path,
+    ) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        // Create the directory that libseccomp's output will be written to.
+        // Technically, we don't have to do this and can extract it from `libseccomp/src/.libs/` after
+        // just `make` is done but it's cleaner this way.
+        //
+        // If the directory already exists, we delete it and start over. This should only
+        // happen if the build is being rerun because the environment variables changed, or the
+        // build itself failed.
+        let mut build_output_path = out_dir.to_path_buf();
+        build_output_path.push("libseccomp-build-out");
+
+        if build_output_path.exists() {
+            std::fs::remove_dir_all(&build_output_path)?;
         }
-        Ok(link_type) => link_type, // static or dylib
-        Err(_) => String::from("dylib"),
-    };
+        std::fs::create_dir(&build_output_path)?;
 
-    println!("cargo:rustc-link-lib={}=seccomp", link_type);
+        // Get compiler flags info.
+        let cc_info = if cfg!(target_env = "musl") {
+            // _FORTIFY_SOURCE=2 is not supported by musl, but it is set by default on some
+            // platforms.
+            cc::Build::new()
+                .flag("-U_FORTIFY_SOURCE")
+                .flag("-D_FORTIFY_SOURCE=1")
+                .get_compiler()
+        } else {
+            cc::Build::new().get_compiler()
+        };
 
-    Ok(())
+        let cc_env = cc_info.cc_env();
+        let cflags_env = cc_info.cflags_env();
+
+        let makeflags = std::env::var("CARGO_MAKEFLAGS")
+            .expect("cargo makeflags are always set in build scripts");
+
+        // TODO: Investigate (via more testing) whether we should be setting some combination of
+        // --host, --build, and --target when cross-compiling, or if setting CC via the cc crate is
+        // sufficient.
+        let configure_result = std::process::Command::new("./configure")
+            .current_dir(&src_path)
+            .args(["--prefix", build_output_path.to_str().unwrap()])
+            .arg(format!("CFLAGS={}", cflags_env.to_str().unwrap()))
+            .arg(format!("CC={}", cc_env.to_str().unwrap()))
+            .spawn()?
+            .wait()?;
+        if !configure_result.success() {
+            return Err("Running `configure` failed while building libseccomp.".into());
+        }
+
+        let make_result = std::process::Command::new("make")
+            .current_dir(&src_path)
+            .env("MAKEFLAGS", &makeflags)
+            .spawn()?
+            .wait()?;
+
+        if !make_result.success() {
+            return Err("Running `make` failed while building libseccomp.".into());
+        }
+
+        let make_install_result = std::process::Command::new("make")
+            .current_dir(&src_path)
+            .env("MAKEFLAGS", &makeflags)
+            .arg("install")
+            .spawn()?
+            .wait()?;
+        if !make_install_result.success() {
+            return Err("Running `make install` failed while building libseccomp.".into());
+        }
+
+        Ok(build_output_path)
+    }
+
+    // NOTE: We could replace the calls to external programs here with the reqwest, flate2, and
+    // sha2 crates but it would increase the build-time compile time (on the first run), in
+    // exchange for not having to have those commands installed on the machine building the crate.
+    /// Uses curl, tar, and sha256sum to download, extract, and verify the libseccomp source.
+    fn download_libseccomp(out_dir: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let url = LIBSECCOMP
+            .url_template
+            .replace("%VERSION%", LIBSECCOMP.version);
+        let tarball_name = url
+            .split('/')
+            .next_back()
+            .expect("get the filename from the url");
+
+        use std::process::Command;
+
+        let curl_result = Command::new("curl")
+            .current_dir(out_dir)
+            .args(["-s", "-L", "-O"])
+            .arg(&url)
+            .spawn()?
+            .wait()?;
+        assert!(
+            curl_result.success(),
+            "Running `curl` failed while building libseccomp."
+        );
+
+        let mut shasum_process = Command::new("sha256sum")
+            .current_dir(out_dir)
+            .stdin(std::process::Stdio::piped())
+            .args(["--check", "--status", "--strict"])
+            .spawn()?;
+
+        let shasum_stdin = shasum_process
+            .stdin
+            .as_mut()
+            .expect("couldn't acquire stdin of child sh256asum process");
+        shasum_stdin
+            .write_all(format!("{}  {}\n", LIBSECCOMP.sha256sum, tarball_name).as_bytes())?;
+
+        let shasum_result = shasum_process.wait()?;
+        assert!(
+            shasum_result.success(),
+            "Running `sha256sum` failed while building libseccomp."
+        );
+
+        let tar_result = Command::new("tar")
+            .current_dir(out_dir)
+            .args(["-xf", tarball_name])
+            .spawn()?
+            .wait()?;
+        assert!(
+            tar_result.success(),
+            "Running `tar` failed while building libseccomp."
+        );
+
+        let mut src_dir = out_dir.to_path_buf();
+        src_dir.push(["libseccomp-", LIBSECCOMP.version].join(""));
+
+        Ok(src_dir)
+    }
+}
+
+mod build_linked {
+    use super::*;
+    use std::path::Path;
+
+    pub fn link(
+        lib_path: Option<&Path>,
+        lib_link_type: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // If the lib path is set via environment variable, use that to tell cargo where to find
+        // libseccomp.
+        // Otherwise, use the passed path if it's set from the build step.
+        if let Ok(path) = env::var(LIBSECCOMP_LIB_PATH) {
+            println!("cargo:rustc-link-search=native={}", path);
+        } else if let Some(path) = lib_path {
+            println!("cargo:rustc-link-search=native={}", path.to_str().unwrap());
+        }
+
+        let link_type = match env::var(LIBSECCOMP_LINK_TYPE) {
+            Ok(link_type) if link_type == "framework" => {
+                return Err("Seccomp is a Linux specific technology".into());
+            }
+            Ok(link_type) => link_type, // static or dylib
+            Err(_) => {
+                if let Some(link_type) = lib_link_type {
+                    String::from(link_type)
+                } else {
+                    String::from("dylib")
+                }
+            }
+        };
+
+        println!("cargo:rustc-link-lib={}=seccomp", link_type);
+
+        Ok(())
+    }
 }

--- a/libseccomp-sys/versions.rs
+++ b/libseccomp-sys/versions.rs
@@ -1,0 +1,18 @@
+#![allow(dead_code)]
+//! Contains versioning information about dependencies outside Cargo. This file is used by the
+//! build.rs build script.
+
+/// Information about external dependencies using during the build.
+pub struct SourceInfo {
+    pub description: &'static str,
+    pub url_template: &'static str,
+    pub version: &'static str,
+    pub sha256sum: &'static str,
+}
+
+pub static LIBSECCOMP: SourceInfo = SourceInfo {
+    description: "High level interface to Linux seccomp filter",
+    url_template: "https://github.com/seccomp/libseccomp/releases/download/v%VERSION%/libseccomp-%VERSION%.tar.gz",
+    version: "2.5.3",
+    sha256sum: "59065c8733364725e9721ba48c3a99bbc52af921daf48df4b1e012fbc7b10a76",
+};

--- a/libseccomp/Cargo.toml
+++ b/libseccomp/Cargo.toml
@@ -14,6 +14,10 @@ readme = "../README.md"
 libc = "0.2.108"
 libseccomp-sys = { version = "0.2.1", path = "../libseccomp-sys" }
 
+[features]
+# Allows downloading and building libseccomp at build time.
+bundled = ["libseccomp-sys/bundled"]
+
 [build-dependencies]
 pkg-config = "0.3.19"
 

--- a/libseccomp/build.rs
+++ b/libseccomp/build.rs
@@ -22,10 +22,15 @@ fn main() {
         env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
     }
 
-    if pkg_config::Config::new()
-        .atleast_version("2.5.0")
-        .probe("libseccomp")
-        .is_ok()
+    // The bundled version of libseccomp will always be > 2.5.
+    // NOTE: We are relying here on the fact that || short-circuits in rust, so that we don't call
+    // pkg_config::Config::probe if the bundled feature is enabled, because probe will output cargo
+    // build flags to link libseccomp dynamically if it's found.
+    if cfg!(feature = "bundled")
+        || pkg_config::Config::new()
+            .atleast_version("2.5.0")
+            .probe("libseccomp")
+            .is_ok()
     {
         println!("cargo:rustc-cfg=libseccomp_v2_5");
     }

--- a/scripts/install_libseccomp.sh
+++ b/scripts/install_libseccomp.sh
@@ -31,8 +31,8 @@ function build_and_install_gperf() {
     ./configure --prefix="${gperf_install_dir}"
     make
     make install
-    export PATH=$PATH:"${gperf_install_dir}"/bin
     popd
+    export PATH=$PATH:"${gperf_install_dir}"/bin
     echo "Gperf installed successfully"
 }
 
@@ -104,7 +104,9 @@ function main() {
 
     pushd "${WORK_DIR}"
     # gperf is required for building the libseccomp.
-    build_and_install_gperf
+	if ! command -v gperf 1>/dev/null; then
+		build_and_install_gperf
+	fi
     build_and_install_libseccomp
     popd
 }


### PR DESCRIPTION
Hi!

I'm building an easy-to-use wrapper around libseccomp and your library is really great!

I wanted to build it with musl and found it was a bit annoying because my linux distribution doesn't include a static version of libseccomp, so I added a `bundled` feature like [rusqlite's](https://github.com/rusqlite/rusqlite).

I went ahead and wrote the code but there are a couple of issues I'm not sure about. Let me know what you think and if you even think it's worth having this feature at all!

1. The code I added downloads the source from the github release.
  a. Would you instead prefer, like rusqlite, to include a copy of the libseccomp source code with the distribution?
2. Maintenance
  a. If we stick with downloading, the libseccomp version and checksum need to be manually updated when new versions of libseccomp are released.
  b. If we move to bundling, the libseccomp source would need to be manually updated.
3. I'm not 100% sure what the pkg-config in the libseccomp build.rs is doing or if it needs to be modified. It doesn't seem like it since I can build, e.g. for i686-unknown-linux-musl and run the tests without an issue.
4. Currently the build.rs code requires curl, tar, sha256sum and make to build libseccomp. It's possible to replace pretty much all of them with native rust dependencies, at the expense of increasing the build dependencies and build time.
  a. It might be reasonable to replace curl with git since it's more likely git will be installed given that we're building a Rust package.
5. Testing. I've tested locally by e.g. adding the i686-unknown-linux-musl target with rustup and running the tests, but haven't added it as a step in the github workflow.


Commit message:

```
This allows libseccomp to be cross-compiled, linked with musl, etc.

Requires curl, tar, sha256sum to build when the feature is enabled. Adds
the cc crate as a dependency, which is only built when the bundled
feature is enabled.
```