### PR TITLE
Remove third-party directory from libseccomp-sys

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libseccomp-sys/third-party/libseccomp"]
-	path = libseccomp-sys/third-party/libseccomp
-	url = https://github.com/seccomp/libseccomp.git


### PR DESCRIPTION
Remove the third party directory from libseccomp-sys to stay out license discussion.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>