### PR TITLE
Fix doc comment for set_ctl_nnp

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -1431,8 +1431,6 @@ impl ScmpFilterContext {
     /// Sets the state of the [`ScmpFilterAttr::CtlNnp`] attribute which will be applied
     /// on filter load.
     ///
-    /// Filters with the [`ScmpFilterAttr::CtlNnp`] attribute set to on (`state` == `true`) can only
-    /// be loaded if the process has the CAP_SYS_ADMIN capability.
     /// Settings this to off (`state` == `false`) means that loading the seccomp filter
     /// into the kernel fill fail if the CAP_SYS_ADMIN is missing.
     ///


### PR DESCRIPTION
The descritpion for `set_ctl_nnp` when the argument is `state==true`
is wrong, so remove the comment.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>