### PR TITLE
example: Fix is_arch_present for aarch64

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -948,7 +948,6 @@ impl ScmpFilterContext {
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-    /// assert!(!ctx.is_arch_present(ScmpArch::Aarch64)?);
     /// ctx.add_arch(ScmpArch::Aarch64)?;
     /// assert!(ctx.is_arch_present(ScmpArch::Aarch64)?);
     /// # Ok::<(), Box<dyn std::error::Error>>(())


### PR DESCRIPTION
Current example code for `is_arch_present` fails on aarch64
because native architecture is added to a filter by default.
Hence, remove `assert!(!ctx.is_arch_present(ScmpArch::Aarch64)?);`.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>