### PR TITLE
Re-export notify module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl PartialEq<i32> for ScmpSyscall` and `impl PartialEq<ScmpSyscall> for i32`
 
 ### Changed
+- Re-export `notify` module with private so that users can use the more convenient
+structure (**Incompatible change**).
 
 ### Removed
 - `Syscall` trait

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -49,14 +49,14 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod error;
-#[cfg(any(libseccomp_v2_5, doc))]
-pub mod notify;
 
 mod action;
 mod arch;
 mod arg_compare;
 mod compare_op;
 mod filter_attr;
+#[cfg(any(libseccomp_v2_5, doc))]
+mod notify;
 mod version;
 
 use error::ErrorKind::*;
@@ -72,6 +72,8 @@ pub use arch::ScmpArch;
 pub use arg_compare::ScmpArgCompare;
 pub use compare_op::ScmpCompareOp;
 pub use filter_attr::ScmpFilterAttr;
+#[cfg(any(libseccomp_v2_5, doc))]
+pub use notify::*;
 pub use version::ScmpVersion;
 
 /// Represents a syscall number.

--- a/libseccomp/tests/notify.rs
+++ b/libseccomp/tests/notify.rs
@@ -1,8 +1,7 @@
 #![cfg(libseccomp_v2_5)]
 
 use libc::{dup3, O_CLOEXEC};
-use libseccomp::notify::*;
-use libseccomp::{check_api, ScmpAction, ScmpArch, ScmpFilterContext, ScmpSyscall, ScmpVersion};
+use libseccomp::*;
 use std::thread;
 
 macro_rules! skip_if_not_supported {


### PR DESCRIPTION
Re-export notify module with private so that users can use the more
convenient structure. This is a breaking change because the notify
module's visibility is no longer public. We do this intentionally
to keep the documentation clean.

Fixes: #130

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>