### PR TITLE
Rework SeccompError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl From<ScmpSyscall> for i32`
 - `impl fmt::Display for ScmpSyscall`
 - `impl PartialEq<i32> for ScmpSyscall` and `impl PartialEq<ScmpSyscall> for i32`
+- `SeccompError::errno` + `SeccompErrno` to query the errno returned by the libseccomp API.
 
 ### Changed
 - Re-export `notify` module with private so that users can use the more convenient
 structure (**Incompatible change**).
+- `add_arch`/`remove_arch` return `Ok(false)` if the architecture was already
+present/not present in the filter and `Ok(true)` if the architecture was really
+added/removed (**Incompatible change**).
+- `get_api` returns `u32` instead `Result<u32>` (**Incompatible change**).
+- `ScmpArch::native()` panics instead of returning an error (**Incompatible change**).
 
 ### Removed
 - `Syscall` trait
+- `get_native_arch()`
+- `enum error::ErrorKind`
+- `type error::Result`
 
 ### Fixed
 - `scmp_cmp!`: `allow(unused_parens)` in `$mask`

--- a/libseccomp/src/arch.rs
+++ b/libseccomp/src/arch.rs
@@ -112,19 +112,11 @@ impl ScmpArch {
     /// This function corresponds to
     /// [`seccomp_arch_native`](https://man7.org/linux/man-pages/man3/seccomp_arch_native.3.html).
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// If this function encounters an issue while getting the native architecture,
-    /// an error will be returned.
-    pub fn native() -> Result<Self> {
-        let ret = unsafe { seccomp_arch_native() };
-
-        match Self::from_sys(ret) {
-            Ok(v) => Ok(v),
-            Err(_) => Err(SeccompError::new(Common(
-                "Could not get native architecture".to_string(),
-            ))),
-        }
+    /// This function panics if it can not get the native architecture.
+    pub fn native() -> Self {
+        Self::from_sys(unsafe { seccomp_arch_native() }).expect("Could not get native architecture")
     }
 }
 

--- a/libseccomp/src/functions.rs
+++ b/libseccomp/src/functions.rs
@@ -71,9 +71,3 @@ pub fn get_syscall_from_name(name: &str, arch: Option<ScmpArch>) -> Result<i32> 
 pub fn get_library_version() -> Result<ScmpVersion> {
     ScmpVersion::current()
 }
-
-/// Deprecated alias for [`ScmpArch::native()`].
-#[deprecated(since = "0.2.0", note = "Use ScmpArch::native().")]
-pub fn get_native_arch() -> Result<ScmpArch> {
-    ScmpArch::native()
-}

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -63,7 +63,6 @@ mod notify;
 mod syscall;
 mod version;
 
-use error::ErrorKind::*;
 use error::{Result, SeccompError};
 
 pub use action::ScmpAction;
@@ -83,6 +82,6 @@ fn cvt(ret: i32) -> Result<()> {
     if ret == 0 {
         Ok(())
     } else {
-        Err(SeccompError::new(Errno(ret)))
+        Err(SeccompError::from_errno(ret))
     }
 }

--- a/libseccomp/src/notify.rs
+++ b/libseccomp/src/notify.rs
@@ -5,7 +5,6 @@
 
 use super::cvt;
 use crate::api::ensure_supported_api;
-use crate::error::ErrorKind::*;
 use crate::error::{Result, SeccompError};
 use crate::{ScmpArch, ScmpFilterContext, ScmpVersion};
 use libseccomp_sys::*;
@@ -64,7 +63,7 @@ impl ScmpFilterContext {
 
         let ret = unsafe { seccomp_notify_fd(self.as_ptr()) };
         if ret < 0 {
-            return Err(SeccompError::new(Errno(ret)));
+            return Err(SeccompError::from_errno(ret));
         }
 
         Ok(ret)
@@ -158,7 +157,7 @@ impl ScmpNotifReq {
                 continue;
             } else {
                 unsafe { seccomp_notify_free(req_ptr, std::ptr::null_mut()) };
-                return Err(SeccompError::new(Errno(ret)));
+                return Err(SeccompError::from_errno(ret));
             }
         }
 
@@ -255,7 +254,7 @@ impl ScmpNotifResp {
                 continue;
             } else {
                 unsafe { seccomp_notify_free(std::ptr::null_mut(), resp_ptr) };
-                return Err(SeccompError::new(Errno(ret)));
+                return Err(SeccompError::from_errno(ret));
             }
         }
 
@@ -296,7 +295,7 @@ pub fn notify_id_valid(fd: ScmpFd, id: u64) -> Result<()> {
         } else if errno == libc::EINTR {
             continue;
         } else {
-            return Err(SeccompError::new(Errno(ret)));
+            return Err(SeccompError::from_errno(ret));
         }
     }
 

--- a/libseccomp/src/syscall.rs
+++ b/libseccomp/src/syscall.rs
@@ -3,7 +3,6 @@
 // Copyright 2021 Sony Group Corporation
 //
 
-use crate::error::ErrorKind::*;
 use crate::error::{Result, SeccompError};
 use crate::ScmpArch;
 use libseccomp_sys::*;
@@ -83,10 +82,10 @@ impl ScmpSyscall {
         let name_c = CString::new(name)?;
         let nr = unsafe { seccomp_syscall_resolve_name_arch(arch.to_sys(), name_c.as_ptr()) };
         if nr == __NR_SCMP_ERROR {
-            return Err(SeccompError::new(Common(format!(
+            return Err(SeccompError::with_msg(format!(
                 "Could not resolve syscall name {}",
                 name
-            ))));
+            )));
         }
 
         Ok(Self { nr })
@@ -121,10 +120,10 @@ impl ScmpSyscall {
         let name_c = CString::new(name)?;
         let nr = unsafe { seccomp_syscall_resolve_name_rewrite(arch.to_sys(), name_c.as_ptr()) };
         if nr == __NR_SCMP_ERROR {
-            return Err(SeccompError::new(Common(format!(
+            return Err(SeccompError::with_msg(format!(
                 "Could not resolve syscall name {}",
                 name
-            ))));
+            )));
         }
 
         Ok(Self { nr })
@@ -183,10 +182,10 @@ impl ScmpSyscall {
     pub fn get_name_by_arch(self, arch: ScmpArch) -> Result<String> {
         let ret = unsafe { seccomp_syscall_resolve_num_arch(arch.to_sys(), self.to_sys()) };
         if ret.is_null() {
-            return Err(SeccompError::new(Common(format!(
+            return Err(SeccompError::with_msg(format!(
                 "Could not resolve syscall number {}",
                 self.nr
-            ))));
+            )));
         }
 
         let name = unsafe { CStr::from_ptr(ret) }.to_str()?.to_string();

--- a/libseccomp/src/version.rs
+++ b/libseccomp/src/version.rs
@@ -3,7 +3,6 @@
 // Copyright 2021 Sony Group Corporation
 //
 
-use crate::error::ErrorKind::*;
 use crate::error::{Result, SeccompError};
 use libseccomp_sys::*;
 use std::fmt;
@@ -37,9 +36,7 @@ impl ScmpVersion {
                 micro: version.micro,
             })
         } else {
-            Err(SeccompError::new(Common(
-                "Could not get seccomp version".to_string(),
-            )))
+            Err(SeccompError::with_msg("Could not get libseccomp version"))
         }
     }
 }
@@ -111,10 +108,10 @@ pub(crate) fn ensure_supported_version(msg: &str, expected: ScmpVersion) -> Resu
         Ok(())
     } else {
         let current = ScmpVersion::current()?;
-        Err(SeccompError::new(Common(format!(
+        Err(SeccompError::with_msg(format!(
             "{} requires libseccomp >= {} (current version: {})",
             msg, expected, current,
-        ))))
+        )))
     }
 }
 

--- a/libseccomp/tests/notify.rs
+++ b/libseccomp/tests/notify.rs
@@ -30,7 +30,7 @@ fn test_user_notification() {
 
     let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow).unwrap();
     let syscall = ScmpSyscall::from_name("dup3").unwrap();
-    let arch = ScmpArch::native().unwrap();
+    let arch = ScmpArch::native();
 
     ctx.add_arch(arch).unwrap();
     ctx.add_rule(ScmpAction::Notify, syscall).unwrap();

--- a/libseccomp/tests/tests.rs
+++ b/libseccomp/tests/tests.rs
@@ -35,23 +35,21 @@ fn test_get_library_version() {
 }
 
 #[test]
-#[allow(deprecated)]
-fn test_get_native_arch() {
-    let ret = ScmpArch::native().unwrap();
-    assert_eq!(ret, get_native_arch().unwrap());
+fn test_scmparch_native() {
+    let ret = ScmpArch::native();
     println!("test_get_native_arch: native arch is {:?}", ret);
 }
 
 #[test]
 fn test_get_api() {
-    let ret = get_api().unwrap();
+    let ret = get_api();
     println!("test_get_api: Got API level of {}", ret);
 }
 
 #[test]
 fn test_set_api() {
     set_api(1).unwrap();
-    assert_eq!(get_api().unwrap(), 1);
+    assert_eq!(get_api(), 1);
 
     assert!(set_api(1000).is_err());
 }
@@ -247,7 +245,7 @@ fn test_arch_functions() {
 fn test_merge_filters() {
     let mut ctx1 = ScmpFilterContext::new_filter(ScmpAction::Allow).unwrap();
     let mut ctx2 = ScmpFilterContext::new_filter(ScmpAction::Allow).unwrap();
-    let native_arch = ScmpArch::native().unwrap();
+    let native_arch = ScmpArch::native();
     let mut prospective_arch = ScmpArch::Aarch64;
 
     if native_arch == ScmpArch::Aarch64 {


### PR DESCRIPTION
Closes #134
Closes #137

Public changes:
- Add `SeccompError::errno` + `SeccompErrno` to query the errno returned
  by the libseccomp API. (#137)
- Change `add_arch`/`remove_arch` to return `Ok(false)` if the
  architecture was already present/not present in the filter and
  `Ok(true)` if the architecture was really added/removed
  (**Incompatible change**). (#137)
- Change `get_api` to return `u32` instead of `Result<u32>`
  (**Incompatible change**).
- Change `ScmpArch::native()` to panic instead of returning an error
  (**Incompatible change**).
- Remove `get_native_arch()`
- Make `ErrorKind` and `Result` private.

Internal changes:
- Add `SeccompError::with_msg` and `SeccompError::with_msg_and_source`
  (dead_code ATM) as sugar for `SeccompError::new(Common("..."))`.
- Add `SeccompError::from_errno`
- Change `ErrorKind::Common` and unnecessary allocations.
- Change `SeccompError::msg` to avoid unnecessary allocations.

Signed-off-by: rusty-snake <41237666+rusty-snake@users.noreply.github.com>