### PR TITLE
Fix extra clippy warnings

### DIFF
--- a/libseccomp/src/action.rs
+++ b/libseccomp/src/action.rs
@@ -67,9 +67,9 @@ impl ScmpAction {
     ///
     /// * `action` - A string action, e.g. `SCMP_ACT_*`.
     ///
-    /// See the [seccomp_rule_add(3)] man page for details on valid action values.
+    /// See the [`seccomp_rule_add(3)`] man page for details on valid action values.
     ///
-    /// [seccomp_rule_add(3)]: https://www.man7.org/linux/man-pages/man3/seccomp_rule_add.3.html
+    /// [`seccomp_rule_add(3)`]: https://www.man7.org/linux/man-pages/man3/seccomp_rule_add.3.html
     ///
     /// # Errors
     ///
@@ -78,8 +78,7 @@ impl ScmpAction {
     pub fn from_str(action: &str, val: Option<i32>) -> Result<Self> {
         match action {
             "SCMP_ACT_KILL_PROCESS" => Ok(Self::KillProcess),
-            "SCMP_ACT_KILL_THREAD" => Ok(Self::KillThread),
-            "SCMP_ACT_KILL" => Ok(Self::KillThread),
+            "SCMP_ACT_KILL_THREAD" | "SCMP_ACT_KILL" => Ok(Self::KillThread),
             "SCMP_ACT_TRAP" => Ok(Self::Trap),
             "SCMP_ACT_NOTIFY" => Ok(Self::Notify),
             "SCMP_ACT_ERRNO" => match val {

--- a/libseccomp/src/api.rs
+++ b/libseccomp/src/api.rs
@@ -12,9 +12,9 @@ use libseccomp_sys::*;
 /// Sets the API level forcibly.
 ///
 /// General use of this function is strongly discouraged.
-/// See the [seccomp_api_get(3)] man page for details on available API levels.
+/// See the [`seccomp_api_get(3)`] man page for details on available API levels.
 ///
-/// [seccomp_api_get(3)]: https://www.man7.org/linux/man-pages/man3/seccomp_api_get.3.html
+/// [`seccomp_api_get(3)`]: https://www.man7.org/linux/man-pages/man3/seccomp_api_get.3.html
 ///
 /// # Arguments
 ///
@@ -38,9 +38,9 @@ pub fn set_api(level: u32) -> Result<()> {
 /// Gets the API level supported by the system.
 ///
 /// This function returns a positive int containing the API level.
-/// See the [seccomp_api_get(3)] man page for details on available API levels.
+/// See the [`seccomp_api_get(3)`] man page for details on available API levels.
 ///
-/// [seccomp_api_get(3)]: https://www.man7.org/linux/man-pages/man3/seccomp_api_get.3.html
+/// [`seccomp_api_get(3)`]: https://www.man7.org/linux/man-pages/man3/seccomp_api_get.3.html
 ///
 /// # Errors
 ///

--- a/libseccomp/src/arch.rs
+++ b/libseccomp/src/arch.rs
@@ -134,9 +134,9 @@ impl FromStr for ScmpArch {
     ///
     /// * `arch` - A string architecture, e.g. `SCMP_ARCH_*`.
     ///
-    /// See the [seccomp_arch_add(3)] man page for details on valid architecture values.
+    /// See the [`seccomp_arch_add(3)`] man page for details on valid architecture values.
     ///
-    /// [seccomp_arch_add(3)]: https://www.man7.org/linux/man-pages/man3/seccomp_arch_add.3.html
+    /// [`seccomp_arch_add(3)`]: https://www.man7.org/linux/man-pages/man3/seccomp_arch_add.3.html
     ///
     /// # Errors
     ///

--- a/libseccomp/src/compare_op.rs
+++ b/libseccomp/src/compare_op.rs
@@ -55,9 +55,9 @@ impl FromStr for ScmpCompareOp {
     ///
     /// * `cmp_op` - A string comparison operator, e.g. `SCMP_CMP_*`.
     ///
-    /// See the [seccomp_rule_add(3)] man page for details on valid comparison operator values.
+    /// See the [`seccomp_rule_add(3)`] man page for details on valid comparison operator values.
     ///
-    /// [seccomp_rule_add(3)]: https://www.man7.org/linux/man-pages/man3/seccomp_rule_add.3.html
+    /// [`seccomp_rule_add(3)`]: https://www.man7.org/linux/man-pages/man3/seccomp_rule_add.3.html
     ///
     /// # Errors
     ///

--- a/libseccomp/src/filter_attr.rs
+++ b/libseccomp/src/filter_attr.rs
@@ -70,9 +70,9 @@ impl FromStr for ScmpFilterAttr {
     ///
     /// * `attr` - A string filter attribute, e.g. `SCMP_FLTATR_*`.
     ///
-    /// See the [seccomp_attr_set(3)] man page for details on valid filter attribute values.
+    /// See the [`seccomp_attr_set(3)`] man page for details on valid filter attribute values.
     ///
-    /// [seccomp_attr_set(3)]: https://www.man7.org/linux/man-pages/man3/seccomp_attr_set.3.html
+    /// [`seccomp_attr_set(3)`]: https://www.man7.org/linux/man-pages/man3/seccomp_attr_set.3.html
     ///
     /// # Errors
     ///

--- a/libseccomp/src/filter_context.rs
+++ b/libseccomp/src/filter_context.rs
@@ -34,12 +34,12 @@ impl ScmpFilterContext {
     /// # Errors
     ///
     /// If the filter context can not be created, an error will be returned.
-    pub fn new_filter(default_action: ScmpAction) -> Result<ScmpFilterContext> {
+    pub fn new_filter(default_action: ScmpAction) -> Result<Self> {
         let ctx_ptr = unsafe { seccomp_init(default_action.to_sys()) };
         let ctx = NonNull::new(ctx_ptr)
             .ok_or_else(|| SeccompError::new(Common("Could not create new filter".to_string())))?;
 
-        Ok(ScmpFilterContext { ctx })
+        Ok(Self { ctx })
     }
 
     /// Merges two filters.
@@ -241,7 +241,7 @@ impl ScmpFilterContext {
                 action.to_sys(),
                 syscall.into().to_sys(),
                 comparators.len() as u32,
-                comparators.as_ptr() as *const scmp_arg_cmp,
+                comparators.as_ptr().cast::<scmp_arg_cmp>(),
             )
         })
     }
@@ -313,7 +313,7 @@ impl ScmpFilterContext {
                 action.to_sys(),
                 syscall.into().to_sys(),
                 comparators.len() as u32,
-                comparators.as_ptr() as *const scmp_arg_cmp,
+                comparators.as_ptr().cast::<scmp_arg_cmp>(),
             )
         })
     }
@@ -540,9 +540,9 @@ impl ScmpFilterContext {
     /// * `attr` - A seccomp filter attribute
     /// * `value` - A value of or the parameter of the attribute
     ///
-    /// See the [seccomp_attr_set(3)] man page for details on available attribute values.
+    /// See the [`seccomp_attr_set(3)`] man page for details on available attribute values.
     ///
-    /// [seccomp_attr_set(3)]: https://www.man7.org/linux/man-pages/man3/seccomp_attr_set.3.html
+    /// [`seccomp_attr_set(3)`]: https://www.man7.org/linux/man-pages/man3/seccomp_attr_set.3.html
     ///
     /// # Errors
     ///
@@ -582,7 +582,7 @@ impl ScmpFilterContext {
     /// on filter load.
     ///
     /// Settings this to off (`state` == `false`) means that loading the seccomp filter
-    /// into the kernel fill fail if the CAP_SYS_ADMIN is missing.
+    /// into the kernel fill fail if the `CAP_SYS_ADMIN` is missing.
     ///
     /// Defaults to on (`state` == `true`).
     ///

--- a/libseccomp/src/notify.rs
+++ b/libseccomp/src/notify.rs
@@ -260,7 +260,9 @@ impl ScmpNotifResp {
 ///
 /// A return value of `Ok` means the notification is still valid.
 /// Otherwise the notification is not valid. This can be used to mitigate
-/// time-of-check-time-of-use (TOCTOU) attacks as described in seccomp_notify_id_valid(2).
+/// time-of-check-time-of-use (TOCTOU) attacks as described in [`seccomp_notify_id_valid(2)`].
+///
+/// [`seccomp_notify_id_valid(2)`]: https://man7.org/linux/man-pages/man3/seccomp_notify_id_valid.3.html
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
Fix warnings reported by
 - `cargo clippy -- -W clippy::pedantic -A clippy::module_name_repetitions -A clippy::wildcard_imports -A clippy::enum_glob_use`
 - `cargo clippy -- -W clippy::nursery -A clippy::option_if_let_else -A clippy::redundant_pub_crate -A clippy::missing_const_for_fn`
that sound legit.

Signed-off-by: rusty-snake <41237666+rusty-snake@users.noreply.github.com>