### PR TITLE
`scmp_cmp!`: `allow(unused_parens)` in `$mask`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ structure (**Incompatible change**).
 ### Removed
 - `Syscall` trait
 
+### Fixed
+- `scmp_cmp!`: `allow(unused_parens)` in `$mask`
+
 ## 0.2.3 - 2022-02-14
 ### Added
 - `"SCMP_ARCH_MIPS64N32"` to `ScmpArch::from_str()`.

--- a/libseccomp/src/arg_compare.rs
+++ b/libseccomp/src/arg_compare.rs
@@ -148,13 +148,15 @@ macro_rules! scmp_cmp {
             $datum,
         )
     };
-    ($_:tt $arg:tt & $mask:tt == $datum:expr) => {
+    ($_:tt $arg:tt & $mask:tt == $datum:expr) => {{
+        #[allow(unused_parens)]
+        let mask = $mask;
         $crate::ScmpArgCompare::new(
             $crate::__private_scmp_cmp_arg!($arg),
-            $crate::ScmpCompareOp::MaskedEqual($mask),
+            $crate::ScmpCompareOp::MaskedEqual(mask),
             $datum,
         )
-    };
+    }};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`$mask` takes an token-tree, because expr can not be followed by `==`
due to Ambiguity Restrictions. This means if `$mask` is more than one
token (e.g. `1234` or `FOO_BAR` are one token but `crate::mod::FOO_BAR`
or `foo(1, 3)` more than one token) you need to put them in a
token-tree (e.g. `(crate::mod::FOO_BAR)` or `(foo(1, 3))`). This will
trigger the `unused_parens` lint in rust (default: warn) after the
expansion.