### PR TITLE
ci: Add cross compilation test for supported architectures

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -72,6 +72,32 @@ jobs:
       - name: Run test
         run: cargo test --target ${{ matrix.target }} -- --nocapture --test-threads 1
 
+  cross:
+    name: Cross Compilation
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - i686-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - arm-unknown-linux-gnueabihf
+          - mips-unknown-linux-gnu
+          - mips64-unknown-linux-gnuabi64
+          - powerpc-unknown-linux-gnu
+          - powerpc64-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install libseccomp
+        run: sudo apt-get install libseccomp-dev
+      - name: Install Rust toolchain
+        run: rustup target add ${{ matrix.target }}
+      - name: Build crate
+        run: cargo build --target ${{ matrix.target }} --all-features
+
   doc:
     name: Documentation Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add cross compilation test for supported architectures to CI in order
to check if the libseccomp crate can be built for the architectures.
In this test, we just use the libseccomp deb package for dynamic linking.
This test will be helpful for https://github.com/libseccomp-rs/libseccomp-rs/pull/125.

Target architectures for the cross compilation:
- x86, aarch64, arm, mips, mips64, powerpc, powerpc64, riscv, and s390x

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>