### PR TITLE
Add config for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    


### PR DESCRIPTION
Add a config file for the dependabot in order to enable it to analyze the crate version.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>