### PR TITLE
Mark notify structs non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ added/removed (**Incompatible change**).
 - `get_api` returns `u32` instead `Result<u32>` (**Incompatible change**).
 - `ScmpArch::native()` panics instead of returning an error (**Incompatible change**).
 - `ScmpNotifData.syscall` is now `ScmpSyscall` instead of `i32` (**Incompatible change**).
+- Marked `ScmpNotifData`, `ScmpNotifReq` and `ScmpNotifResp` `#[non_exhaustive]` (**Incompatible change**).
 
 ### Deprecated
 - `NOTIF_FLAG_CONTINUE` use `ScmpNotifRespFlags::CONTINUE.bits()` instead.

--- a/libseccomp/src/notify.rs
+++ b/libseccomp/src/notify.rs
@@ -95,6 +95,7 @@ impl ScmpFilterContext {
 
 /// Describes the system call context that triggered a notification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub struct ScmpNotifData {
     /// The syscall number
     pub syscall: ScmpSyscall,
@@ -119,6 +120,7 @@ impl ScmpNotifData {
 
 /// Represents a userspace notification request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub struct ScmpNotifReq {
     /// Notification ID
     pub id: u64,
@@ -200,6 +202,7 @@ impl ScmpNotifReq {
 
 /// Represents a userspace notification response.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub struct ScmpNotifResp {
     /// Notification ID (must match the corresponding `ScmpNotifReq` ID)
     pub id: u64,

--- a/libseccomp/tests/notify.rs
+++ b/libseccomp/tests/notify.rs
@@ -113,30 +113,15 @@ fn test_user_notification() {
 fn test_resp_new() {
     assert_eq!(
         ScmpNotifResp::new_val(1234, 1, ScmpNotifRespFlags::empty()),
-        ScmpNotifResp {
-            id: 1234,
-            val: 1,
-            error: 0,
-            flags: 0,
-        },
+        ScmpNotifResp::new(1234, 1, 0, 0),
     );
     assert_eq!(
         ScmpNotifResp::new_error(1234, -2, ScmpNotifRespFlags::empty()),
-        ScmpNotifResp {
-            id: 1234,
-            val: 0,
-            error: -2,
-            flags: 0,
-        },
+        ScmpNotifResp::new(1234, 0, -2, 0),
     );
     assert_eq!(
         ScmpNotifResp::new_continue(1234, ScmpNotifRespFlags::empty()),
-        ScmpNotifResp {
-            id: 1234,
-            val: 0,
-            error: 0,
-            flags: ScmpNotifRespFlags::CONTINUE.bits(),
-        },
+        ScmpNotifResp::new(1234, 0, 0, ScmpNotifRespFlags::CONTINUE.bits()),
     );
 }
 


### PR DESCRIPTION
These structs mirror the kernel types which may change with future development in the kernel.

Fixes #172