### PR TITLE
Dependabot: Add package-ecosystem github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
     


### PR DESCRIPTION
This will keep the used actions in your worklfows up-to-date.

As a future step we can also [follow GitHub Actions security best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and pin actions to a full length commit SHA.