### PR TITLE
Fix regression from fe7bd6a/#143

### DIFF
--- a/libseccomp/src/arg_compare.rs
+++ b/libseccomp/src/arg_compare.rs
@@ -148,15 +148,16 @@ macro_rules! scmp_cmp {
             $datum,
         )
     };
-    ($_:tt $arg:tt & $mask:tt == $datum:expr) => {{
-        #[allow(unused_parens)]
-        let mask = $mask;
+    ($_:tt $arg:tt & $mask:tt == $datum:expr) => {
         $crate::ScmpArgCompare::new(
             $crate::__private_scmp_cmp_arg!($arg),
-            $crate::ScmpCompareOp::MaskedEqual(mask),
+            $crate::ScmpCompareOp::MaskedEqual(
+                #[allow(unused_parens)]
+                $mask,
+            ),
             $datum,
         )
-    }};
+    };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
```rust
let comperators: &[ScmpArgCompare] = &[scmp_cmp!($arg0 & 123 == 123)];
```

Used to work before fe7bd6a/#143 but fail now with "creates a temporary which is freed while still in use". Refactoing the macro back to CallExpression instead of BlockExpression as utmost token fixes it. However IIRC there was a reason why I did not made it that way in the first place and IIRC it wasn't working because attributes in that position were unstable. This would effect MSRV (#135). Nevermind, I can not find anything about this in rust/RELEASES.md or with an internet search, neither my tries with older compilers made it fail that why.