### PR TITLE
Correct `socket` conditional rule example

### DIFF
--- a/libseccomp/src/filter_context.rs
+++ b/libseccomp/src/filter_context.rs
@@ -357,7 +357,7 @@ impl ScmpFilterContext {
     /// ctx.add_rule_conditional_exact(
     ///     ScmpAction::Errno(libc::EPERM),
     ///     syscall,
-    ///     &[scmp_cmp!($arg1 != libc::AF_UNIX as u64)],
+    ///     &[scmp_cmp!($arg0 != libc::AF_UNIX as u64)],
     /// )?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```


### PR DESCRIPTION
Socket 'family' is the _first_ arg, not second.  Thus the test should be `$arg0 != AF_UNIX`.

Fixes #189