### PR TITLE
Comment coverage job for now

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -181,21 +181,21 @@ jobs:
       - name: Verify that the libseccomp crate version is up to date in README
         run: grep -q "$(sed -n 's/^version = \(.*\)/libseccomp = \1/p' libseccomp/Cargo.toml)" README.md
 
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        features:
-          - all-features
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh
-      - name: Run cargo tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: '--${{ matrix.features }} -- --test-threads 1'
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+#  coverage:
+#    name: Code Coverage
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        features:
+#          - all-features
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#      - name: Install upstream libseccomp
+#        run: sudo ./scripts/install_libseccomp.sh
+#      - name: Run cargo tarpaulin
+#        uses: actions-rs/tarpaulin@v0.1
+#        with:
+#          args: '--${{ matrix.features }} -- --test-threads 1'
+#      - name: Upload to codecov.io
+#        uses: codecov/codecov-action@v3


### PR DESCRIPTION
cargo-tarpaulin changed the nameing of release artifacts over three month ago. Unmaintained actions-rs/tarpaulin did not picked it up until now breaking CI.

Ref: https://github.com/actions-rs/tarpaulin/issues/15

We still want to replace the action with an other action, an direct call to cargo-taroaulin or use grcov, see #188.