### PR TITLE
Fix: ScmpFilterContext::{get,set}_ctl_optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimum Supported Rust Version (MSRV): 1.46
 
 ### Changed
+- `get_api_sysrawrc` and `set_api_sysrawrc` can now be used with any API level.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `get_api_sysrawrc` and `set_api_sysrawrc` can now be used with any API level.
+- `get_ctl_optimize` and `set_ctl_optimize` can now be used with any API level.
 
 ### Removed
 

--- a/libseccomp/src/filter_context.rs
+++ b/libseccomp/src/filter_context.rs
@@ -5,6 +5,7 @@
 
 use crate::api::ensure_supported_api;
 use crate::error::{Result, SeccompError};
+use crate::version::ensure_supported_version;
 use libseccomp_sys::*;
 use std::os::unix::io::AsRawFd;
 use std::ptr::NonNull;
@@ -690,7 +691,7 @@ impl ScmpFilterContext {
     ///
     /// This function returns `Ok(true)` if the [`ScmpFilterAttr::ApiSysRawRc`] attribute set to on the filter
     /// being loaded, `Ok(false)` otherwise.
-    /// The [`ScmpFilterAttr::ApiSysRawRc`] attribute is only usable when the libseccomp API level 4 or higher
+    /// The [`ScmpFilterAttr::ApiSysRawRc`] attribute is only usable when the libseccomp version 2.5.0 or higher
     /// is supported.
     ///
     /// This function corresponds to
@@ -699,21 +700,21 @@ impl ScmpFilterContext {
     /// # Errors
     ///
     /// If this function is called with an invalid filter, an issue is encountered
-    /// getting the current state, or the libseccomp API level is less than 4, an error will be returned.
+    /// getting the current state, or the libseccomp version is less than 2.5.0, an error will be returned.
     ///
     /// # Examples
     ///
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-    /// # if check_api(4, ScmpVersion::from((2, 5, 0)))? {
+    /// # if check_version(ScmpVersion::from((2, 5, 0)))? {
     /// ctx.set_api_sysrawrc(true)?;
     /// assert!(ctx.get_api_sysrawrc()?);
     /// # }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_api_sysrawrc(&self) -> Result<bool> {
-        ensure_supported_api("get_api_sysrawrc", 4, ScmpVersion::from((2, 5, 0)))?;
+        ensure_supported_version("get_api_sysrawrc", ScmpVersion::from((2, 5, 0)))?;
         let ret = self.get_filter_attr(ScmpFilterAttr::ApiSysRawRc)?;
 
         Ok(ret != 0)
@@ -967,7 +968,7 @@ impl ScmpFilterContext {
     ///
     /// Settings this to on (`state` == `true`) means that the libseccomp should pass system error codes
     /// back to the caller instead of the default -ECANCELED.
-    /// The [`ScmpFilterAttr::ApiSysRawRc`] attribute is only usable when the libseccomp API level 4 or higher
+    /// The [`ScmpFilterAttr::ApiSysRawRc`] attribute is only usable when the libseccomp version 2.5.0 or higher
     /// is supported.
     ///
     /// Defaults to off (`state` == `false`).
@@ -983,20 +984,20 @@ impl ScmpFilterContext {
     /// # Errors
     ///
     /// If this function is called with an invalid filter, an issue is encountered
-    /// setting the attribute, or the libseccomp API level is less than 4, an error will be returned.
+    /// setting the attribute, or the libseccomp version is less than 2.5.0, an error will be returned.
     ///
     /// # Examples
     ///
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-    /// # if check_api(4, ScmpVersion::from((2, 5, 0)))? {
+    /// # if check_version(ScmpVersion::from((2, 5, 0)))? {
     /// ctx.set_api_sysrawrc(true)?;
     /// # }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn set_api_sysrawrc(&mut self, state: bool) -> Result<()> {
-        ensure_supported_api("set_api_sysrawrc", 4, ScmpVersion::from((2, 5, 0)))?;
+        ensure_supported_version("set_api_sysrawrc", ScmpVersion::from((2, 5, 0)))?;
         self.set_filter_attr(ScmpFilterAttr::ApiSysRawRc, state.into())
     }
 

--- a/libseccomp/src/filter_context.rs
+++ b/libseccomp/src/filter_context.rs
@@ -658,7 +658,7 @@ impl ScmpFilterContext {
     ///
     /// See [`set_ctl_optimize()`](ScmpFilterContext::set_ctl_optimize) for more details about
     /// the optimization level.
-    /// The [`ScmpFilterAttr::CtlOptimize`] attribute is only usable when the libseccomp API level 4 or higher
+    /// The [`ScmpFilterAttr::CtlOptimize`] attribute is only usable when the libseccomp version 2.5.0 or higher
     /// is supported.
     ///
     /// This function corresponds to
@@ -667,21 +667,21 @@ impl ScmpFilterContext {
     /// # Errors
     ///
     /// If this function is called with an invalid filter, an issue is encountered
-    /// getting the current state, or the libseccomp API level is less than 4, an error will be returned.
+    /// getting the current state, or the libseccomp version is less than 2.5.0, an error will be returned.
     ///
     /// # Examples
     ///
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-    /// # if check_api(4, ScmpVersion::from((2, 5, 0)))? {
+    /// # if check_version(ScmpVersion::from((2, 5, 0)))? {
     /// ctx.set_ctl_optimize(2)?;
     /// assert_eq!(ctx.get_ctl_optimize()?, 2);
     /// # }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_ctl_optimize(&self) -> Result<u32> {
-        ensure_supported_api("get_ctl_optimize", 4, ScmpVersion::from((2, 5, 0)))?;
+        ensure_supported_version("get_ctl_optimize", ScmpVersion::from((2, 5, 0)))?;
         let ret = self.get_filter_attr(ScmpFilterAttr::CtlOptimize)?;
 
         Ok(ret)
@@ -929,7 +929,7 @@ impl ScmpFilterContext {
     /// consistent O(log n) filter traversal for every rule in the filter. The binary tree may be advantageous
     /// for large filters. Note that [`set_syscall_priority()`](ScmpFilterContext::set_syscall_priority) is
     /// ignored when `level` == `2`.
-    /// The [`ScmpFilterAttr::CtlOptimize`] attribute is only usable when the libseccomp API level 4 or higher
+    /// The [`ScmpFilterAttr::CtlOptimize`] attribute is only usable when the libseccomp version 2.5.0 or higher
     /// is supported.
     ///
     /// The different optimization levels are described below:
@@ -947,20 +947,20 @@ impl ScmpFilterContext {
     /// # Errors
     ///
     /// If this function is called with an invalid filter, an issue is encountered
-    /// setting the attribute, or the libseccomp API level is less than 4, an error will be returned.
+    /// setting the attribute, or the libseccomp version is less than 2.5.0, an error will be returned.
     ///
     /// # Examples
     ///
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
-    /// # if check_api(4, ScmpVersion::from((2, 5, 0)))? {
+    /// # if check_version(ScmpVersion::from((2, 5, 0)))? {
     /// ctx.set_ctl_optimize(2)?;
     /// # }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn set_ctl_optimize(&mut self, level: u32) -> Result<()> {
-        ensure_supported_api("set_ctl_optimize", 4, ScmpVersion::from((2, 5, 0)))?;
+        ensure_supported_version("set_ctl_optimize", ScmpVersion::from((2, 5, 0)))?;
         self.set_filter_attr(ScmpFilterAttr::CtlOptimize, level)
     }
 

--- a/libseccomp/tests/tests.rs
+++ b/libseccomp/tests/tests.rs
@@ -121,7 +121,7 @@ fn test_filter_attributes() {
 
     // Test for CtlOptimize
     let opt_level = 2;
-    if check_api(4, ScmpVersion::from((2, 5, 0))).unwrap() {
+    if check_version(ScmpVersion::from((2, 5, 0))).unwrap() {
         ctx.set_ctl_optimize(opt_level).unwrap();
         let ret = ctx.get_ctl_optimize().unwrap();
         assert_eq!(ret, opt_level);

--- a/libseccomp/tests/tests.rs
+++ b/libseccomp/tests/tests.rs
@@ -131,7 +131,7 @@ fn test_filter_attributes() {
     }
 
     // Test for ApiSysRawRc
-    if check_api(4, ScmpVersion::from((2, 5, 0))).unwrap() {
+    if check_version(ScmpVersion::from((2, 5, 0))).unwrap() {
         ctx.set_api_sysrawrc(true).unwrap();
         let ret = ctx.get_api_sysrawrc().unwrap();
         assert!(ret);


### PR DESCRIPTION
`get_ctl_optimize` and `set_ctl_optimize` can now be used with any API level.