### PR TITLE
sys: Add new raw architectures, action, and functions

### DIFF
--- a/libseccomp-sys/src/lib.rs
+++ b/libseccomp-sys/src/lib.rs
@@ -156,6 +156,8 @@ pub enum scmp_filter_attr {
     SCMP_FLTATR_CTL_OPTIMIZE = 8,
     /// return the system return codes
     SCMP_FLTATR_API_SYSRAWRC = 9,
+    /// request wait killable semantics
+    SCMP_FLTATR_CTL_WAITKILL = 10,
     _SCMP_FLTATR_MAX,
 }
 
@@ -209,6 +211,8 @@ pub const SCMP_ARCH_X86_64: u32 = 0xc000003e;
 pub const SCMP_ARCH_X32: u32 = 0x4000003e;
 pub const SCMP_ARCH_ARM: u32 = 0x40000028;
 pub const SCMP_ARCH_AARCH64: u32 = 0xc00000b7;
+pub const SCMP_ARCH_LOONGARCH64: u32 = 0xc0000102;
+pub const SCMP_ARCH_M68K: u32 = 0x4;
 pub const SCMP_ARCH_MIPS: u32 = 0x8;
 pub const SCMP_ARCH_MIPS64: u32 = 0x80000008;
 pub const SCMP_ARCH_MIPS64N32: u32 = 0xa0000008;
@@ -223,6 +227,8 @@ pub const SCMP_ARCH_S390X: u32 = 0x80000016;
 pub const SCMP_ARCH_PARISC: u32 = 0xf;
 pub const SCMP_ARCH_PARISC64: u32 = 0x8000000f;
 pub const SCMP_ARCH_RISCV64: u32 = 0xc00000f3;
+pub const SCMP_ARCH_SHEB: u32 = 0x2a;
+pub const SCMP_ARCH_SH: u32 = 0x4000002a;
 
 pub const SCMP_ACT_MASK: u32 = SECCOMP_RET_ACTION_FULL;
 /// Kill the process
@@ -638,6 +644,29 @@ extern "C" {
     /// This function generates seccomp Berkeley Packer Filter (BPF) code and writes
     /// it to the given fd.  Returns zero on success, negative values on failure.
     pub fn seccomp_export_bpf(ctx: const_scmp_filter_ctx, fd: c_int) -> c_int;
+
+    /// Generate seccomp Berkeley Packet Filter (BPF) code and export it to a buffer
+    ///
+    /// - `ctx`: the filter context
+    /// - `buf`: the destination buffer
+    /// - `len`: on input the length of the buffer, on output the number of bytes in the program
+    ///
+    /// This function generates seccomp Berkeley Packer Filter (BPF) code and writes
+    /// it to the given buffer.  Returns zero on success, negative values on failure.
+    pub fn seccomp_export_bpf_mem(
+        ctx: const_scmp_filter_ctx,
+        buf: *mut c_void,
+        len: *mut usize,
+    ) -> c_int;
+
+    ///  Precompute the seccomp filter for future use
+    ///
+    ///  - `ctx`: the filter context
+    ///
+    ///  This function precomputes the seccomp filter and stores it internally for
+    ///  future use, speeding up [`seccomp_load()`] and other functions which require
+    ///  the generated filter.
+    pub fn seccomp_precompute(ctx: const_scmp_filter_ctx) -> c_int;
 }
 
 /// Negative pseudo syscall number returned by some functions in case of an error


### PR DESCRIPTION
Add the following architectures:
- 64-bit loongarch64 (https://github.com/seccomp/libseccomp/commit/6966ec77b195ac289ae168c7c5646d59a307f33f)
- 32-bit m68k (https://github.com/seccomp/libseccomp/commit/dd5c9c24e8ba11c9c3ee6b60c93cef64a9ad5c86)
- 32-bit sheb (https://github.com/seccomp/libseccomp/commit/c12945db0b7e32f409ba3a68d18c6d6f6dd22b19)
- 32-bit sh (https://github.com/seccomp/libseccomp/commit/c12945db0b7e32f409ba3a68d18c6d6f6dd22b19)

Add the following action:
- `SCMP_FLTATR_CTL_WAITKILL` (https://github.com/seccomp/libseccomp/commit/96989965042a515a3cbcb50e9b98243b9b7d4c37)

Add the following functions:
- `seccomp_export_bpf_mem` (https://github.com/seccomp/libseccomp/commit/3f0e47fe2717b73ccef68ca18f9f7297ee73ebb2)
- `seccomp_precompute` (https://github.com/seccomp/libseccomp/commit/e797591bdd6834272e2db292400f608ed9bd7fab)