### PR TITLE
Bump bitlfags to 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Non-breaking
 - `get_api_sysrawrc` and `set_api_sysrawrc` can now be used with any API level.
 - `get_ctl_optimize` and `set_ctl_optimize` can now be used with any API level.
+- Rust 2021 Edition
 
 #### breaking, caught by compiler
 - `ScmpFilterContext::{add,remove}_arch` return type changed to `Result<()>`.
   If you actually used the returned bool, call `ScmpFilterContext::is_arch_present` first.
 - Rename `ScmpFilterContext::new_filter` to `ScmpFilterContext::new`.
+
+#### silent breaking, not caught by compiler
+- Updated bitflags dependency to `~2.3.3`
 
 ### Removed
 

--- a/libseccomp/Cargo.toml
+++ b/libseccomp/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 readme = "../README.md"
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "~2.3.3"
 cfg-if = { version = "1.0.0", optional = true }
 libc = "0.2.108"
 libseccomp-sys = { version = "0.2.1", path = "../libseccomp-sys" }

--- a/libseccomp/src/notify.rs
+++ b/libseccomp/src/notify.rs
@@ -37,18 +37,11 @@ pub type ScmpFd = RawFd;
 
 bitflags! {
     /// Userspace notification response flags
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct ScmpNotifRespFlags: u32 {
         /// Tells the kernel to continue executing the system call that triggered the
         /// notification. Must only be used when the notification response's error and value is 0.
         const CONTINUE = SECCOMP_USER_NOTIF_FLAG_CONTINUE;
-    }
-}
-impl ScmpNotifRespFlags {
-    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    // https://github.com/bitflags/bitflags/issues/263
-    #[must_use]
-    pub fn from_bits_preserve(bits: u32) -> Self {
-        Self { bits }
     }
 }
 
@@ -58,9 +51,9 @@ impl ScmpNotifRespFlags {
 /// notification. Must only be used when the notification response's error is 0.
 #[deprecated(
     since = "0.3.0",
-    note = "Use ScmpNotifRespFlags::CONTINUE or ScmpNotifRespFlags::CONTINUE.bits"
+    note = "Use ScmpNotifRespFlags::CONTINUE or ScmpNotifRespFlags::CONTINUE.bits()"
 )]
-pub const NOTIF_FLAG_CONTINUE: u32 = ScmpNotifRespFlags::CONTINUE.bits;
+pub const NOTIF_FLAG_CONTINUE: u32 = ScmpNotifRespFlags::CONTINUE.bits();
 
 impl ScmpFilterContext {
     /// Gets a file descriptor for the userspace notification associated with the
@@ -271,7 +264,7 @@ impl ScmpNotifResp {
             id,
             val,
             error: 0,
-            flags: flags.bits,
+            flags: flags.bits(),
         }
     }
 
@@ -295,7 +288,7 @@ impl ScmpNotifResp {
             id,
             val: 0,
             error,
-            flags: flags.bits,
+            flags: flags.bits(),
         }
     }
 
@@ -317,7 +310,7 @@ impl ScmpNotifResp {
             id,
             val: 0,
             error: 0,
-            flags: ScmpNotifRespFlags::CONTINUE.bitor(flags).bits,
+            flags: ScmpNotifRespFlags::CONTINUE.bitor(flags).bits(),
         }
     }
 

--- a/libseccomp/tests/notify.rs
+++ b/libseccomp/tests/notify.rs
@@ -137,11 +137,3 @@ fn test_error() {
     assert!(resp.respond(0).is_err());
     assert!(notify_id_valid(0, 0).is_err());
 }
-
-#[test]
-fn resp_flags_from_bits_preserve() {
-    assert_eq!(
-        ScmpNotifRespFlags::from_bits_preserve(u32::MAX).bits(),
-        u32::MAX
-    );
-}


### PR DESCRIPTION
- bitflags is part of our public API
- bitflags 2 has breaking changes
- bitflags 2 had a turbulent beginning, I therefore pinned it to it's minor release (patch release behave normally).

Fixes #197

~~CI will fail because of msrv.~~