### PR TITLE
`seccomp_export_bpf_mem`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   You can however create and export seccomp-bpf for them.
 - `SeccompError::sysrawrc()` that queries the system's raw error code directly returned
   by `ScmpFilterAttr::ApiSysRawRc`.
+- `ScmpFilterContext::export_bpf_mem`
 
 ### Changed
 

--- a/libseccomp/tests/tests.rs
+++ b/libseccomp/tests/tests.rs
@@ -332,11 +332,19 @@ fn test_export_functions() {
 
     let mut invalid_fd: File = unsafe { std::fs::File::from_raw_fd(-2) };
 
+    assert!(ctx.export_pfc(&mut stdout()).is_ok());
+    assert!(ctx.export_pfc(&mut invalid_fd).is_err());
+
     assert!(ctx.export_bpf(&mut stdout()).is_ok());
     assert!(ctx.export_bpf(&mut invalid_fd).is_err());
 
-    assert!(ctx.export_pfc(&mut stdout()).is_ok());
-    assert!(ctx.export_pfc(&mut invalid_fd).is_err());
+    #[cfg(libseccomp_v2_6)]
+    {
+        let ctx = ScmpFilterContext::new(ScmpAction::Allow).unwrap();
+        let buf = ctx.export_bpf_mem().unwrap();
+        assert!(buf.len() > 0);
+        assert!(buf.iter().copied().any(|byte| byte > 0));
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #121

ToDo:

- [x] Where should the cfg go? The function, Separated `impl`, Separated `impl` in new module.