### PR TITLE
ci: Add test for the upstream libseccomp library

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libseccomp-version: [2.4.3, 2.5.1, 2.5.3, 2.5.4]
+        libseccomp-version: [v2.4.3, v2.5.1, v2.5.3, v2.5.4, main]
     env:
       LIBSECCOMP_LINK_TYPE: dylib
       LIBSECCOMP_LIB_PATH: /usr/local/libseccomp/lib
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libseccomp-version: [2.4.3, 2.5.1, 2.5.3, 2.5.4]
+        libseccomp-version: [v2.4.3, v2.5.1, v2.5.3, v2.5.4, main]
         target:
           - x86_64-unknown-linux-musl
     env:


### PR DESCRIPTION
In order to test new APIs that haven't released officially yet in the upstream libseccomp library, add the CI test for them using the main of the upstream repository.