### PR TITLE
error: Add SeccompError::sysrawrc() api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `loongarch64`, `m68k`, `sheb` and `sh` architectures. Note that Rust has
   no support for `SuperH` so you can not use libseccomp-rs on such architectures.
   You can however create and export seccomp-bpf for them.
+- `SeccompError::sysrawrc()` that queries the system's raw error code directly returned
+  by `ScmpFilterAttr::ApiSysRawRc`.
 
 ### Changed
 


### PR DESCRIPTION
The `SeccompError::sysrawrc()` api queries the system's raw error code returned
when something goes wrong in the libc and the kernel. This api will be useful
for users who want to extract the system's error code directly returned by the
`ScmpFilterAttr::ApiSysRawRc`, or get the errno returned by the libseccomp API
as a negative integer rather than `SeccompErrno`.

For example, with `ScmpFilterAttr::ApiSysRawRc` enabled, the `ScmpFilterContext::load()`
and `ScmpFilterContext::export_{bpf,pfc}()` have a possibility that returns
system's error codes such as `EBUSY`, `EBADF`, etc. These error codes are not
extracted by `SeccompError::errno()`. Instead, you can use `SeccompError::sysrawrc()`
that deals with all the system error codes returned by the system.
Regarding the usage in detail, refer to the example code in the documentation.

Fixes: #161, #206