### PR TITLE
Drop the libseccomp < 2.5.0 support

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libseccomp-version: [v2.4.3, v2.5.1, v2.5.3, v2.5.4, main]
+        libseccomp-version: [v2.5.0, v2.5.1, v2.5.3, v2.5.4, main]
     env:
       LIBSECCOMP_LINK_TYPE: dylib
       LIBSECCOMP_LIB_PATH: /usr/local/libseccomp/lib
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libseccomp-version: [v2.4.3, v2.5.1, v2.5.3, v2.5.4, main]
+        libseccomp-version: [v2.5.0, v2.5.1, v2.5.3, v2.5.4, main]
         target:
           - x86_64-unknown-linux-musl
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated bitflags dependency to `~2.3.3`
 
 ### Removed
+- Drop the libseccomp < 2.5.0 support.
 
 ## 0.3.0 - 2022-10-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Requirements
 Before using the libseccomp crate, you need to install the libseccomp library for your system.
-The libseccomp library version 2.4 or newer is required.
+The libseccomp library version 2.5.0 or newer is required.
 
 ### Installing the libseccomp library from a package
 

--- a/libseccomp/build.rs
+++ b/libseccomp/build.rs
@@ -23,10 +23,10 @@ fn main() {
     }
 
     if pkg_config::Config::new()
-        .atleast_version("2.5.0")
+        .atleast_version("2.6.0")
         .probe("libseccomp")
         .is_ok()
     {
-        println!("cargo:rustc-cfg=libseccomp_v2_5");
+        println!("cargo:rustc-cfg=libseccomp_v2_6");
     }
 }

--- a/libseccomp/src/filter_context.rs
+++ b/libseccomp/src/filter_context.rs
@@ -5,7 +5,6 @@
 
 use crate::api::ensure_supported_api;
 use crate::error::{Result, SeccompError};
-use crate::version::ensure_supported_version;
 use libseccomp_sys::*;
 use std::os::unix::io::AsRawFd;
 use std::ptr::NonNull;
@@ -685,14 +684,11 @@ impl ScmpFilterContext {
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new(ScmpAction::Allow)?;
-    /// # if check_version(ScmpVersion::from((2, 5, 0)))? {
     /// ctx.set_ctl_optimize(2)?;
     /// assert_eq!(ctx.get_ctl_optimize()?, 2);
-    /// # }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_ctl_optimize(&self) -> Result<u32> {
-        ensure_supported_version("get_ctl_optimize", ScmpVersion::from((2, 5, 0)))?;
         let ret = self.get_filter_attr(ScmpFilterAttr::CtlOptimize)?;
 
         Ok(ret)
@@ -718,14 +714,11 @@ impl ScmpFilterContext {
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new(ScmpAction::Allow)?;
-    /// # if check_version(ScmpVersion::from((2, 5, 0)))? {
     /// ctx.set_api_sysrawrc(true)?;
     /// assert!(ctx.get_api_sysrawrc()?);
-    /// # }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn get_api_sysrawrc(&self) -> Result<bool> {
-        ensure_supported_version("get_api_sysrawrc", ScmpVersion::from((2, 5, 0)))?;
         let ret = self.get_filter_attr(ScmpFilterAttr::ApiSysRawRc)?;
 
         Ok(ret != 0)
@@ -968,13 +961,10 @@ impl ScmpFilterContext {
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new(ScmpAction::Allow)?;
-    /// # if check_version(ScmpVersion::from((2, 5, 0)))? {
     /// ctx.set_ctl_optimize(2)?;
-    /// # }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn set_ctl_optimize(&mut self, level: u32) -> Result<()> {
-        ensure_supported_version("set_ctl_optimize", ScmpVersion::from((2, 5, 0)))?;
         self.set_filter_attr(ScmpFilterAttr::CtlOptimize, level)
     }
 
@@ -1005,13 +995,10 @@ impl ScmpFilterContext {
     /// ```
     /// # use libseccomp::*;
     /// let mut ctx = ScmpFilterContext::new(ScmpAction::Allow)?;
-    /// # if check_version(ScmpVersion::from((2, 5, 0)))? {
     /// ctx.set_api_sysrawrc(true)?;
-    /// # }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn set_api_sysrawrc(&mut self, state: bool) -> Result<()> {
-        ensure_supported_version("set_api_sysrawrc", ScmpVersion::from((2, 5, 0)))?;
         self.set_filter_attr(ScmpFilterAttr::ApiSysRawRc, state.into())
     }
 

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -72,7 +72,6 @@ mod compare_op;
 mod filter_attr;
 mod filter_context;
 mod functions;
-#[cfg(any(libseccomp_v2_5, doc))]
 mod notify;
 mod syscall;
 mod version;
@@ -87,7 +86,6 @@ pub use compare_op::ScmpCompareOp;
 pub use filter_attr::ScmpFilterAttr;
 pub use filter_context::ScmpFilterContext;
 pub use functions::*;
-#[cfg(any(libseccomp_v2_5, doc))]
 pub use notify::*;
 pub use syscall::ScmpSyscall;
 pub use version::{check_version, ScmpVersion};

--- a/libseccomp/src/version.rs
+++ b/libseccomp/src/version.rs
@@ -115,7 +115,6 @@ pub fn check_version(expected: ScmpVersion) -> Result<bool> {
 ///
 /// If the libseccomp version being used is less than the specified version,
 /// an error will be returned.
-// This function will not be used if the libseccomp version is less than 2.5.0.
 pub(crate) fn ensure_supported_version(msg: &str, expected: ScmpVersion) -> Result<()> {
     if check_version(expected)? {
         Ok(())
@@ -154,13 +153,19 @@ mod tests {
             ),
             ScmpVersionTest::new("VerMajor-1", ScmpVersion::from((ver.major - 1, 0, 0)), true),
             ScmpVersionTest::new(
-                "VerMinor-1",
-                ScmpVersion::from((ver.major, ver.minor - 1, 0)),
+                // To avoid a failure at v*.0.*
+                "If VerMinor != 0 then VerMinor-1, otherwise VerMinor=0",
+                ScmpVersion::from((ver.major, if ver.minor != 0 { ver.minor - 1 } else { 0 }, 0)),
                 true,
             ),
             ScmpVersionTest::new(
-                "VerMicro-1",
-                ScmpVersion::from((ver.major, ver.minor, ver.micro - 1)),
+                // To avoid a failure at v*.*.0
+                "If VerMicro != 0 then VerMicro-1, otherwise VerMicro=0",
+                ScmpVersion::from((
+                    ver.major,
+                    ver.minor,
+                    if ver.micro != 0 { ver.micro - 1 } else { 0 },
+                )),
                 true,
             ),
             ScmpVersionTest::new(

--- a/libseccomp/tests/notify.rs
+++ b/libseccomp/tests/notify.rs
@@ -1,5 +1,3 @@
-#![cfg(libseccomp_v2_5)]
-
 use libc::{dup3, O_CLOEXEC};
 use libseccomp::*;
 use std::thread;

--- a/libseccomp/tests/tests.rs
+++ b/libseccomp/tests/tests.rs
@@ -120,24 +120,14 @@ fn test_filter_attributes() {
 
     // Test for CtlOptimize
     let opt_level = 2;
-    if check_version(ScmpVersion::from((2, 5, 0))).unwrap() {
-        ctx.set_ctl_optimize(opt_level).unwrap();
-        let ret = ctx.get_ctl_optimize().unwrap();
-        assert_eq!(ret, opt_level);
-    } else {
-        assert!(ctx.set_ctl_optimize(opt_level).is_err());
-        assert!(ctx.get_ctl_optimize().is_err());
-    }
+    ctx.set_ctl_optimize(opt_level).unwrap();
+    let ret = ctx.get_ctl_optimize().unwrap();
+    assert_eq!(ret, opt_level);
 
     // Test for ApiSysRawRc
-    if check_version(ScmpVersion::from((2, 5, 0))).unwrap() {
-        ctx.set_api_sysrawrc(true).unwrap();
-        let ret = ctx.get_api_sysrawrc().unwrap();
-        assert!(ret);
-    } else {
-        assert!(ctx.set_api_sysrawrc(true).is_err());
-        assert!(ctx.get_api_sysrawrc().is_err());
-    }
+    ctx.set_api_sysrawrc(true).unwrap();
+    let ret = ctx.get_api_sysrawrc().unwrap();
+    assert!(ret);
 
     // Test for CtlTsync
     if check_api(2, ScmpVersion::from((2, 2, 0))).unwrap() {


### PR DESCRIPTION
Drop the libseccomp < 2.5.0 support to simplify the code because the upstream no longer supports libseccomp < 2.5.0.

Fixes: #214