### PR TITLE
doc: Show ScmpSyscall::new of const-syscall  with annotation

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -161,8 +161,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install the nightly toolchain
+        run: rustup install nightly
       - name: Generate documentations
-        run: cargo doc --no-deps
+        run: make doc
 
   codespell:
     name: Check Spelling

--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,15 @@ clippy:
 # Clean
 #
 
+doc: doc-libseccomp doc-libseccomp-sys
+
+doc-libseccomp:
+	RUSTDOCFLAGS="--cfg docsrs" \
+	cargo +nightly doc --lib --no-deps --all-features --manifest-path ./libseccomp/Cargo.toml
+
+doc-libseccomp-sys:
+	cargo doc --lib --no-deps --manifest-path ./libseccomp-sys/Cargo.toml
+
+
 clean:
 	cargo clean

--- a/libseccomp/Cargo.toml
+++ b/libseccomp/Cargo.toml
@@ -21,6 +21,7 @@ libseccomp-sys = { version = "0.2.1", path = "../libseccomp-sys" }
 pkg-config = "0.3.19"
 
 [package.metadata.docs.rs]
+all-features = true
 rustc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/libseccomp/src/syscall.rs
+++ b/libseccomp/src/syscall.rs
@@ -86,6 +86,7 @@ impl ScmpSyscall {
     /// let syscall = ScmpSyscall::new("chroot");
     /// ```
     #[cfg(feature = "const-syscall")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "const-syscall")))]
     pub const fn new(name: &str) -> Self {
         let mut i = 0;
         let nr = loop {


### PR DESCRIPTION
Allow the crates.io documentation to show `ScmpSyscall::new()` provided by the `const-syscall` feature with the following annotation.

> Available on crate feature `const-syscall` only.

This is enabled by the `doc_cfg` feature which is available in only the nightly channel, but the `docs.rs` of crates.io is built by the nightly so we don't worry about it. 
Ref. https://docs.rs/about/builds