### PR TITLE
ci: Drop mips/mips64 target from CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -98,8 +98,8 @@ jobs:
           - i686-unknown-linux-gnu
           - loongarch64-unknown-linux-gnu
           #- m68k-unknown-linux-gnu # It is unavailable even in channel 'nightly'.
-          - mips-unknown-linux-gnu
-          - mips64-unknown-linux-gnuabi64
+          #- mips-unknown-linux-gnu # It has been dropped to Tier 3 since 1.72
+          #- mips64-unknown-linux-gnuabi64 # It has been dropped to Tier 3 since 1.72
           - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - riscv64gc-unknown-linux-gnu


### PR DESCRIPTION
`mips-unknown-linux-gnu` and `mips64-unknown-linux-gnuabi64` have been dropped to Tier 3 since rust 1.72 by https://github.com/rust-lang/compiler-team/issues/648.
Hence, they are no longer available even in the nightly channel.