### PR TITLE
example: Stop using ScmpFilterContext::new_filter

### DIFF
--- a/libseccomp/src/filter_context.rs
+++ b/libseccomp/src/filter_context.rs
@@ -1232,7 +1232,7 @@ impl ScmpFilterContext {
     ///
     /// ```
     /// # use libseccomp::*;
-    /// let mut ctx = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
+    /// let mut ctx = ScmpFilterContext::new(ScmpAction::Allow)?;
     /// let syscall = ScmpSyscall::from_name("dup3")?;
     /// ctx.add_rule(ScmpAction::KillThread, syscall)?;
     /// ctx.precompute()?;


### PR DESCRIPTION
Replace `ScmpFilterContext::new_filter()` with `ScmpFilterContext::new()` due to the deprecated function.