### PR TITLE
ci: Add setup action to install upstream libseccomp

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,28 @@
+name: Setup the libseccomp library
+description: Setup the upstream libseccomp library for the libseccomp-rs
+inputs:
+  version:
+    description: Installed the upstream libseccomp version
+    default: main
+    required: false
+  link-type:
+    description: Link type (dylib or static)
+    default: dylib
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install the upstream libseccomp
+      env:
+        LIBSECCOMP_LINK_TYPE: ${{ inputs.link-type }}
+        LIBSECCOMP_LIB_PATH: /usr/local/libseccomp/lib
+      run: |
+        install_dir=$(dirname ${LIBSECCOMP_LIB_PATH})
+        sudo ./scripts/install_libseccomp.sh -m -v ${{ inputs.version }} -i ${install_dir}
+        echo "LD_LIBRARY_PATH=${LIBSECCOMP_LIB_PATH}" >> $GITHUB_ENV
+        echo "LIBSECCOMP_LINK_TYPE=${LIBSECCOMP_LINK_TYPE}" >> $GITHUB_ENV
+        echo "LIBSECCOMP_LIB_PATH=${LIBSECCOMP_LIB_PATH}" >> $GITHUB_ENV
+      shell: bash

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install upstream libseccomp
-        run: sudo ./scripts/install_libseccomp.sh
+        uses: ./.github/actions/setup
       - name: Prepare for rustfmt and clippy
         run: rustup component add rustfmt clippy
       - name: Run rustfmt
@@ -32,17 +32,13 @@ jobs:
       fail-fast: false
       matrix:
         libseccomp-version: [v2.5.0, v2.5.1, v2.5.3, v2.5.4, main]
-    env:
-      LIBSECCOMP_LINK_TYPE: dylib
-      LIBSECCOMP_LIB_PATH: /usr/local/libseccomp/lib
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install upstream libseccomp
-        run: |
-          install_dir=$(dirname ${{ env.LIBSECCOMP_LIB_PATH }})
-          sudo ./scripts/install_libseccomp.sh -v ${{ matrix.libseccomp-version }} -i ${install_dir}
-          echo "LD_LIBRARY_PATH=${{ env.LIBSECCOMP_LIB_PATH }}" >> $GITHUB_ENV
+        uses: ./.github/actions/setup
+        with:
+          version: ${{ matrix.libseccomp-version }}
       - name: Build crate
         run: make debug
       - name: Build crate with all features
@@ -61,9 +57,6 @@ jobs:
         libseccomp-version: [v2.5.0, v2.5.1, v2.5.3, v2.5.4, main]
         target:
           - x86_64-unknown-linux-musl
-    env:
-      LIBSECCOMP_LINK_TYPE: static
-      LIBSECCOMP_LIB_PATH: /usr/local/libseccomp-musl/lib
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -72,9 +65,10 @@ jobs:
       - name: Install musl gcc
         run: sudo apt-get install musl-tools
       - name: Install upstream libseccomp
-        run: |
-          install_dir=$(dirname ${{ env.LIBSECCOMP_LIB_PATH }})
-          sudo ./scripts/install_libseccomp.sh -m -v ${{ matrix.libseccomp-version }} -i ${install_dir}
+        uses: ./.github/actions/setup
+        with:
+          version: ${{ matrix.libseccomp-version }}
+          link-type: static
       - name: Build crate
         run: cargo build --target ${{ matrix.target }}
       - name: Run test
@@ -133,18 +127,12 @@ jobs:
   msrv:
     name: MSRV
     runs-on: ubuntu-latest
-    env:
-      LIBSECCOMP_LINK_TYPE: dylib
-      LIBSECCOMP_LIB_PATH: /usr/local/libseccomp/lib
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust ${{ env.msrv }}
         run: rustup default ${{ env.msrv }}
       - name: Install upstream libseccomp
-        run: |
-          install_dir=$(dirname ${{ env.LIBSECCOMP_LIB_PATH }})
-          sudo ./scripts/install_libseccomp.sh -v main -i ${install_dir}
-          echo "LD_LIBRARY_PATH=${{ env.LIBSECCOMP_LIB_PATH }}" >> $GITHUB_ENV
+        uses: ./.github/actions/setup
       - name: Build crate with all target and features
         run: |
           cargo -vV
@@ -191,18 +179,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      LIBSECCOMP_LINK_TYPE: dylib
-      LIBSECCOMP_LIB_PATH: /usr/local/libseccomp/lib
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install upstream libseccomp
-        run: |
-          install_dir=$(dirname ${{ env.LIBSECCOMP_LIB_PATH }})
-          sudo ./scripts/install_libseccomp.sh -v main -i ${install_dir}
-          echo "LD_LIBRARY_PATH=${{ env.LIBSECCOMP_LIB_PATH }}" >> $GITHUB_ENV
+        uses: ./.github/actions/setup
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info -- --test-threads 1
       - name: Upload coverage to Codecov

--- a/libseccomp/tests/tests.rs
+++ b/libseccomp/tests/tests.rs
@@ -376,7 +376,7 @@ fn test_export_functions() {
     {
         let ctx = ScmpFilterContext::new(ScmpAction::Allow).unwrap();
         let buf = ctx.export_bpf_mem().unwrap();
-        assert!(buf.len() > 0);
+        assert!(!buf.is_empty());
         assert!(buf.iter().copied().any(|byte| byte > 0));
     }
 }


### PR DESCRIPTION
Add our composite action to setup the upstream libseccomp for the crate.
Currently, we write(copy-paste) the same steps to install the libseccomp in various jobs, but it is not good in terms of maintainability.
Let's replace them with the composite action.

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>