### PR TITLE
ci: musl build is enabled only in `static-link-musl` job.

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -21,7 +21,11 @@ runs:
         LIBSECCOMP_LIB_PATH: /usr/local/libseccomp/lib
       run: |
         install_dir=$(dirname ${LIBSECCOMP_LIB_PATH})
-        sudo ./scripts/install_libseccomp.sh -m -v ${{ inputs.version }} -i ${install_dir}
+        args=()
+        if [[ "${{ inputs.link-type }}" == "static" ]]; then
+            args+=("-m")
+        fi
+        sudo ./scripts/install_libseccomp.sh "${args[@]}" -v ${{ inputs.version }} -i ${install_dir}
         echo "LD_LIBRARY_PATH=${LIBSECCOMP_LIB_PATH}" >> $GITHUB_ENV
         echo "LIBSECCOMP_LINK_TYPE=${LIBSECCOMP_LINK_TYPE}" >> $GITHUB_ENV
         echo "LIBSECCOMP_LIB_PATH=${LIBSECCOMP_LIB_PATH}" >> $GITHUB_ENV


### PR DESCRIPTION
The musl build(`./install_libseccomp -m`) is enabled only in the `static-link-musl` job.