### PR TITLE
ci: Enable daily build and workflow dispatch

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
     types: [opened, reopened, edited, synchronize]
+  workflow_dispatch:
+  schedule:
+    - cron: '00 01 * * *'
 
 env:
   msrv: 1.63


### PR DESCRIPTION
Run schedule job at UTC 01:00 every day to detect a failure early. Besides, enable workflow dispatch to be able to run workflow manually.