### PR TITLE
Add the change of `check_version` to `CHANGELOG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IO-Safety for `ScmpFilterContext::export_{bpf,pfc}`.
 
 #### silent breaking, not caught by compiler
+- Changed `check_version` logic not to fail even if the `major` version is greater than the specified version.
 - Updated bitflags dependency to `~2.4.0`
 
 ### Removed


### PR DESCRIPTION
Add a description for the change of `check_version` logic to `CHANGELOG` because the update causes a silent breaking, not caught by compiler.

Fixes: https://github.com/libseccomp-rs/libseccomp-rs/issues/252