### PR TITLE
Run CI against 2.5.5

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libseccomp-version: [v2.5.0, v2.5.1, v2.5.3, v2.5.4, main]
+        libseccomp-version: [v2.5.0, v2.5.1, v2.5.3, v2.5.4, v2.5.5, main]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libseccomp-version: [v2.5.0, v2.5.1, v2.5.3, v2.5.4, main]
+        libseccomp-version: [v2.5.0, v2.5.1, v2.5.3, v2.5.4, v2.5.5, main]
         target:
           - x86_64-unknown-linux-musl
     steps:


### PR DESCRIPTION
Draft because I hope CI fails with libseccomp-rs (main) + libseccomp (2.5.5).