### PR TITLE
test: Replace github_action cfg with check_api

### DIFF
--- a/libseccomp/build.rs
+++ b/libseccomp/build.rs
@@ -6,10 +6,8 @@
 use std::{env, path, str};
 
 const LIBSECCOMP_LIB_PATH: &str = "LIBSECCOMP_LIB_PATH";
-const GITHUB_ACTIONS: &str = "GITHUB_ACTIONS";
 
 fn main() {
-    println!("cargo:rerun-if-env-changed={}", GITHUB_ACTIONS);
     println!("cargo:rerun-if-env-changed={}", LIBSECCOMP_LIB_PATH);
 
     if let Ok(path) = env::var(LIBSECCOMP_LIB_PATH) {
@@ -30,9 +28,5 @@ fn main() {
         .is_ok()
     {
         println!("cargo:rustc-cfg=libseccomp_v2_6");
-    }
-
-    if env::var(GITHUB_ACTIONS).as_deref() == Ok("true") {
-        println!("cargo:rustc-cfg=github_actions");
     }
 }

--- a/libseccomp/tests/tests.rs
+++ b/libseccomp/tests/tests.rs
@@ -151,17 +151,14 @@ fn test_filter_attributes() {
         assert!(ctx.get_ctl_tsync().is_err());
     }
 
-    #[cfg(not(github_actions))]
-    {
-        // Test for CtlWaitkill
-        if check_api(7, ScmpVersion::from((2, 6, 0))).unwrap() {
-            ctx.set_ctl_waitkill(true).unwrap();
-            let ret = ctx.get_ctl_waitkill().unwrap();
-            assert!(ret);
-        } else {
-            assert!(ctx.set_ctl_waitkill(true).is_err());
-            assert!(ctx.get_ctl_waitkill().is_err());
-        }
+    // Test for CtlWaitkill
+    if check_api(7, ScmpVersion::from((2, 6, 0))).unwrap() {
+        ctx.set_ctl_waitkill(true).unwrap();
+        let ret = ctx.get_ctl_waitkill().unwrap();
+        assert!(ret);
+    } else {
+        assert!(ctx.set_ctl_waitkill(true).is_err());
+        assert!(ctx.get_ctl_waitkill().is_err());
     }
 }
 
@@ -300,8 +297,7 @@ fn test_builder_pattern() -> Result<(), Box<dyn std::error::Error>> {
         .set_api_sysrawrc(false)?
         .load()?;
 
-    #[cfg(not(github_actions))]
-    {
+    if check_api(7, ScmpVersion::from((2, 6, 0))).unwrap() {
         ScmpFilterContext::new(ScmpAction::Allow)?
             .set_ctl_waitkill(true)?
             .load()?;


### PR DESCRIPTION
check_api is good enough to pass the test of `set_ctl_waitkill` on an environment which is not satisfied with the condition of the api.