### PR TITLE
Add transaction support

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,7 +10,7 @@ on:
     - cron: '00 01 * * *'
 
 env:
-  msrv: 1.63
+  msrv: 1.67
 
 jobs:
   validate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Minimum Supported Rust Version (MSRV): 1.63
+- Minimum Supported Rust Version (MSRV): 1.67
 - Updated const-syscall definitions to match libseccomp 2.6.0.
 - Support for `loongarch64`, `m68k`, `sheb` and `sh` architectures. Note that Rust has
   no support for `SuperH` so you can not use libseccomp-rs on such architectures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example code for userspace notification functions.
 - `ScmpFilterContext::get_api_tskip` and `ScmpFilterContext::set_api_tskip`
 - Support for `2.5.5` and `2.5.6`
-- Limited support for `2.6.0` (everything except `seccomp_transaction_*`)
+- Support for `2.6.0`
+- `ScmpFilterContext::*_transaction`
 - `ScmpSyscall::is_error` and `ScmpSyscall::is_undef`
 - `ScmpSyscall::from_raw_syscall`, `ScmpSyscall::as_raw_syscall` and `RawSyscall`
 

--- a/libseccomp-sys/Cargo.toml
+++ b/libseccomp-sys/Cargo.toml
@@ -7,5 +7,5 @@ description = "Raw FFI Bindings for the libseccomp Library"
 repository = "https://github.com/libseccomp-rs/libseccomp-rs"
 categories = ["seccomp", "api-bindings"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 readme = "README.md"

--- a/libseccomp-sys/src/lib.rs
+++ b/libseccomp-sys/src/lib.rs
@@ -661,6 +661,39 @@ extern "C" {
         len: *mut usize,
     ) -> c_int;
 
+    /// Start a new seccomp filter transaction
+    ///
+    /// - `ctx`: the filter context
+    ///
+    /// This function starts a new seccomp filter transaction that the caller can use
+    /// to perform any number of filter modifications which can then be committed
+    /// to the filter using [`seccomp_transaction_commit()`] or rejected using
+    /// [`seccomp_transaction_reject()`]. It is important to note that
+    /// transactions only affect the seccomp filter state while it is being
+    /// managed by libseccomp; seccomp filters which have been loaded into the
+    /// kernel can not be modified, only new seccomp filters can be added on top
+    /// of the existing loaded filter stack. Returns zero on success, negative values on failure.
+    pub fn seccomp_transaction_start(ctx: const_scmp_filter_ctx) -> c_int;
+
+    /// Reject a transaction started by [`seccomp_transaction_start`]
+    ///
+    /// - `ctx`: the filter context
+    ///
+    /// This function rejects the current seccomp filter transaction, discarding all
+    /// the filter modifications made during the transaction. Once rejected, the filter
+    /// context remains unchanged as it was before the transaction started.
+    pub fn seccomp_transaction_reject(ctx: scmp_filter_ctx);
+
+    /// Commit a transaction started by [`seccomp_transaction_start`]
+    ///
+    /// - `ctx`: the filter context
+    ///
+    /// This function commits the current seccomp filter transaction, applying all
+    /// the filter modifications made during the transaction to the filter context.
+    /// Once committed, the changes are finalized and cannot be undone.
+    /// Returns zero on success, negative values on failure.
+    pub fn seccomp_transaction_commit(ctx: scmp_filter_ctx) -> c_int;
+
     ///  Precompute the seccomp filter for future use
     ///
     ///  - `ctx`: the filter context

--- a/libseccomp/Cargo.toml
+++ b/libseccomp/Cargo.toml
@@ -7,7 +7,7 @@ description = "Rust Language Bindings for the libseccomp Library"
 repository = "https://github.com/libseccomp-rs/libseccomp-rs"
 keywords = ["bindings", "seccomp", "linux", "containers", "security"]
 categories = ["os", "api-bindings"]
-rust-version = "1.63"
+rust-version = "1.67"
 edition = "2021"
 readme = "../README.md"
 


### PR DESCRIPTION
The followiing three functions are added:

- `ScmpFilterContext::start_transaction`
- `ScmpFilterContext::commit_transaction`
- `ScmpFilterContext::reject_transaction`

These functions are available since libseccomp v2.6.0.