### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+
+### Changed
+
+#### Non-breaking
+
+#### breaking, caught by compiler
+
+#### silent breaking, not caught by compiler
+
+### Removed
+
+## 0.4.0 - 2025-04-04
+### Added
 - Minimum Supported Rust Version (MSRV): 1.67
 - Updated const-syscall definitions to match libseccomp 2.6.0.
 - Support for `loongarch64`, `m68k`, `sheb` and `sh` architectures. Note that Rust has

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest release on crates.io](https://img.shields.io/crates/v/libseccomp.svg)](https://crates.io/crates/libseccomp)
 [![Documentation on docs.rs](https://docs.rs/libseccomp/badge.svg)](https://docs.rs/libseccomp)
 [![codecov](https://codecov.io/gh/libseccomp-rs/libseccomp-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/libseccomp-rs/libseccomp-rs)
-[![MSRV: 1.63](https://img.shields.io/badge/MSRV-1.63-informational)](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
+[![MSRV: 1.67](https://img.shields.io/badge/MSRV-1.67-informational)](https://blog.rust-lang.org/2023/01/26/Rust-1.67.0.html)
 
 Rust Language Bindings for the libseccomp Library
 
@@ -72,7 +72,7 @@ If you want to build the libseccomp library from an official release tarball ins
 you should follow the quick step.
 
 ```sh
-$ LIBSECCOMP_VERSION=2.5.3
+$ LIBSECCOMP_VERSION=2.6.0
 $ wget https://github.com/seccomp/libseccomp/releases/download/v${LIBSECCOMP_VERSION}/libseccomp-${LIBSECCOMP_VERSION}.tar.gz
 $ tar xvf libseccomp-${LIBSECCOMP_VERSION}.tar.gz
 $ cd libseccomp-${LIBSECCOMP_VERSION}
@@ -103,14 +103,14 @@ Now, add the following to your `Cargo.toml` to start building the libseccomp cra
 
 ```toml
 [dependencies]
-libseccomp = "0.3.0"
+libseccomp = "0.4.0"
 ```
 
 ## Minimum Supported Rust Version (MSRV) policy
 
 The 0.3.x line has 1.46 as MSRV.
 
-Starting with 0.4.0, our MSRV will be increased when necessary or appropriate.
+Starting with 0.4.0, our MSRV is increased when necessary or appropriate.
 However, it will never be increased to a version greater than the last stable rust version minus two.
 
 A MSRV change is not considered a breaking change.

--- a/libseccomp-sys/Cargo.toml
+++ b/libseccomp-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libseccomp-sys"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Manabu Sugimoto <Manabu.Sugimoto@sony.com>"]
 license = "MIT OR Apache-2.0"
 description = "Raw FFI Bindings for the libseccomp Library"

--- a/libseccomp-sys/README.md
+++ b/libseccomp-sys/README.md
@@ -14,4 +14,4 @@ Therefore most users should not need to interact with this crate directly.
 
 ## Version information
 
-Currently, the libseccomp-sys supports libseccomp version 2.5.3.
+Currently, the libseccomp-sys supports libseccomp version 2.6.0.

--- a/libseccomp/Cargo.toml
+++ b/libseccomp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libseccomp"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Manabu Sugimoto <Manabu.Sugimoto@sony.com>"]
 license = "MIT OR Apache-2.0"
 description = "Rust Language Bindings for the libseccomp Library"
@@ -15,7 +15,7 @@ readme = "../README.md"
 bitflags = "2.9.0"
 cfg-if = { version = "1.0.0", optional = true }
 libc = "0.2.108"
-libseccomp-sys = { version = "0.2.1", path = "../libseccomp-sys" }
+libseccomp-sys = { version = "0.3.0", path = "../libseccomp-sys" }
 
 [build-dependencies]
 pkg-config = "0.3.19"


### PR DESCRIPTION
- libseccomp: v0.4.0
- libseccomp-sys: v0.3.0